### PR TITLE
Adding apk splits to quickstart

### DIFF
--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -19,6 +19,23 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    // Specify that we want to split up the APK based on ABI
+    splits {
+        abi {
+            // Enable ABI split
+            enable true
+
+            // Clear list of ABIs
+            reset()
+
+            // Specify each architecture currently supported by the Video SDK
+            include "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
+
+            // Specify that we do not want an additional universal SDK
+            universalApk false
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Added example of how to reduce apk size by using [APK Splits](https://developer.android.com/studio/build/configure-apk-splits.html). 