### PR TITLE
Adding example for taking a picture on camera capturer

### DIFF
--- a/exampleAdvancedCameraCapturer/src/main/java/com/twilio/video/examples/advancedcameracapturer/AdvancedCameraCapturerActivity.java
+++ b/exampleAdvancedCameraCapturer/src/main/java/com/twilio/video/examples/advancedcameracapturer/AdvancedCameraCapturerActivity.java
@@ -110,7 +110,7 @@ public class AdvancedCameraCapturerActivity extends Activity {
                 null);
         pictureDialog = new AlertDialog.Builder(this)
                 .setView(pictureImageView)
-                .setTitle(R.string.camera_capturer_picture)
+                .setTitle(null)
                 .setPositiveButton(R.string.close, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(final DialogInterface dialog, int which) {

--- a/exampleAdvancedCameraCapturer/src/main/res/layout/activity_advanced_camera_capturer.xml
+++ b/exampleAdvancedCameraCapturer/src/main/res/layout/activity_advanced_camera_capturer.xml
@@ -8,11 +8,21 @@
         android:id="@+id/video_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>
-    <Button
+    <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:id="@+id/toggle_flash_button"
-        android:text="@string/toggle_flash"
-        android:layout_gravity="bottom|center"
-        android:layout_margin="16dp"/>
+        android:layout_gravity="center|bottom">
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/toggle_flash_button"
+            android:text="@string/toggle_flash"
+            android:layout_margin="16dp"/>
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/take_picture_button"
+            android:text="@string/take_picture"
+            android:layout_margin="16dp"/>
+    </LinearLayout>
 </FrameLayout>

--- a/exampleAdvancedCameraCapturer/src/main/res/layout/picture_image_view.xml
+++ b/exampleAdvancedCameraCapturer/src/main/res/layout/picture_image_view.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ImageView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_marginTop="16dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:scaleType="center"/>

--- a/exampleAdvancedCameraCapturer/src/main/res/values/strings.xml
+++ b/exampleAdvancedCameraCapturer/src/main/res/values/strings.xml
@@ -3,4 +3,8 @@
     <string name="permissions_needed">Need camera permission for example</string>
     <string name="toggle_flash">Toggle Flash</string>
     <string name="flash_not_supported">Flash not supported</string>
+    <string name="take_picture">Take Picture</string>
+    <string name="take_picture_failed">Failed to decode bitmap</string>
+    <string name="camera_capturer_picture">Camera Capturer Picture</string>
+    <string name="close">Close</string>
 </resources>


### PR DESCRIPTION
The picture taken is displayed in a simple `AlertDialog`. I decided against a gallery view because it would require saving images and implementing a `RecyclerView`. Screenshots below.

![device-2016-11-23-105210](https://cloud.githubusercontent.com/assets/1734140/20570925/278a6dc2-b16b-11e6-9beb-9ad846defd2d.png)
![device-2016-11-23-105222](https://cloud.githubusercontent.com/assets/1734140/20570924/2789ecbc-b16b-11e6-8172-4d10ba006ab9.png)
