### PR TITLE
Updates to 1.0.0-beta10 release

### DIFF
--- a/exampleAdvancedCameraCapturer/build.gradle
+++ b/exampleAdvancedCameraCapturer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.0.0-beta9"
+    compile "com.twilio:video-android:1.0.0-beta10"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleCustomVideoCapturer/build.gradle
+++ b/exampleCustomVideoCapturer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.0.0-beta9"
+    compile "com.twilio:video-android:1.0.0-beta10"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleCustomVideoRenderer/build.gradle
+++ b/exampleCustomVideoRenderer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.0.0-beta9"
+    compile "com.twilio:video-android:1.0.0-beta10"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleScreenCapturer/build.gradle
+++ b/exampleScreenCapturer/build.gradle
@@ -26,7 +26,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.0.0-beta9"
+    compile "com.twilio:video-android:1.0.0-beta10"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }


### PR DESCRIPTION
Including content from [1.0.0-beta10 Changelog](https://www.twilio.com/docs/api/video/changelogs/android#100-beta10-february-24-2017)

Improvements

- Network handoff, and subsequent connection renegotiation is now supported for IPv4 networks.

Bug Fixes

- Fixed a regression introduced in 1.0.0-beta8 where tokens with purely numeric identities caused a crash [#64](https://github.com/twilio/video-quickstart-android/issues/64) [#60](https://github.com/twilio/video-quickstart-android/issues/60)
- Participant identities now support UTF-8