### PR TITLE
Update quickstart module to use 1.0.0-beta10

### DIFF
--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
 
     compile 'com.koushikdutta.ion:ion:2.1.7'
-    compile "com.twilio:video-android:1.0.0-beta9"
+    compile "com.twilio:video-android:1.0.0-beta10"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }


### PR DESCRIPTION
I accidentally did not include quickstart module update in #67 . I updated the module and validated the quickstart flow again.