### PR TITLE
Updates for 1.0.0-beta11 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
     }
 }
 

--- a/exampleAdvancedCameraCapturer/build.gradle
+++ b/exampleAdvancedCameraCapturer/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         applicationId "com.twilio.video.examples.advancedcameracapturer"
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.0.0-beta10"
+    compile "com.twilio:video-android:1.0.0-beta11"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleCustomVideoCapturer/build.gradle
+++ b/exampleCustomVideoCapturer/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         applicationId "com.twilio.video.examples.customcapturer"
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.0.0-beta10"
+    compile "com.twilio:video-android:1.0.0-beta11"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleCustomVideoRenderer/build.gradle
+++ b/exampleCustomVideoRenderer/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         applicationId "com.twilio.video.examples.customrenderer"
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.0.0-beta10"
+    compile "com.twilio:video-android:1.0.0-beta11"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleScreenCapturer/build.gradle
+++ b/exampleScreenCapturer/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         applicationId "com.twilio.video.examples.screencapturer"
@@ -26,7 +26,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.0.0-beta10"
+    compile "com.twilio:video-android:1.0.0-beta11"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 19 17:22:17 EDT 2016
+#Mon Mar 06 09:55:05 CST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         applicationId "com.twilio.video.quickstart"
@@ -42,7 +42,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
 
     compile 'com.koushikdutta.ion:ion:2.1.7'
-    compile "com.twilio:video-android:1.0.0-beta10"
+    compile "com.twilio:video-android:1.0.0-beta11"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }


### PR DESCRIPTION
From [1.0.0-beta11 changelog](https://www.twilio.com/docs/api/video/changelogs/android#100-beta11-march-6-2017)

Improvements

- Moved `connect` from instance method to static method on `VideoClient` class. Calling the new static `connect` method requires a `Context` in addition to `ConnectOptions` and a `Room.Listener` . `VideoClient` is no longer an object that can be instantiated and an instance is no longer required to connect to a `Room`.
- Moved access token parameter from `VideoClient` constructor to `ConnectOptions.Builder` constructor. 

Connecting to a `Room` before 1.0.0-beta11

    // Create VideoClient
    VideoClient videoClient = new VideoClient(context, accessToken);
    ConnectOptions connectOptions = new ConnectOptions.Builder()
        .roomName(roomName)
        .localMedia(localMedia)
        .build();
    videoClient.connect(connectOptions, roomListener);

Connecting to a `Room` with static `connect` 

    ConnectOptions connectOptions = new ConnectOptions.Builder(accessToken)
        .roomName(roomName)
        .localMedia(localMedia)
        .build();
    VideoClient.connect(context, connectOptions, roomListener);

Bug Fixes

- Fixed crash when disconnecting from a `Room` on HTC 10.
- Fixed crash caused by removing a track before calling `Room#disconnect` .
- Use a certificate bundle to validate SSL certificates on the signaling connection.
- Improved compatibility with Group Rooms and track added and removed events.