### PR TITLE
Update to 1.0.0-beta13

### DIFF
--- a/exampleAdvancedCameraCapturer/build.gradle
+++ b/exampleAdvancedCameraCapturer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.0.0-beta12"
+    compile "com.twilio:video-android:1.0.0-beta13"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleCustomVideoCapturer/build.gradle
+++ b/exampleCustomVideoCapturer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.0.0-beta12"
+    compile "com.twilio:video-android:1.0.0-beta13"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleCustomVideoRenderer/build.gradle
+++ b/exampleCustomVideoRenderer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.0.0-beta12"
+    compile "com.twilio:video-android:1.0.0-beta13"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleScreenCapturer/build.gradle
+++ b/exampleScreenCapturer/build.gradle
@@ -26,7 +26,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.0.0-beta12"
+    compile "com.twilio:video-android:1.0.0-beta13"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
 
     compile 'com.koushikdutta.ion:ion:2.1.7'
-    compile "com.twilio:video-android:1.0.0-beta12"
+    compile "com.twilio:video-android:1.0.0-beta13"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }


### PR DESCRIPTION
From [1.0.0-beta13 changelog](https://www.twilio.com/docs/api/video/changelogs/android)

Improvements

- Decreased Room connection time by establishing the signaling connection earlier in the process.
- Removed the final case where we resolve localhost. This also improves connection time to your first Room.

Bug Fixes

- Fixed a regression in 1.0.0-beta12 where a track added event was not raised when the trackId was reused. [#83](https://github.com/twilio/video-quickstart-android/issues/83)
- Fixed crash in `Room#disconnect` when releasing `Participant` media
- Resolved memory corruption issues which could occur in multi-party scenarios.
- Fixed a crash which could occur in signaling stack