### PR TITLE
Update to 1.0.0-beta17 release

### DIFF
--- a/exampleAdvancedCameraCapturer/build.gradle
+++ b/exampleAdvancedCameraCapturer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.0.0-beta16"
+    compile "com.twilio:video-android:1.0.0-beta17"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleAdvancedCameraCapturer/src/main/java/com/twilio/video/examples/advancedcameracapturer/AdvancedCameraCapturerActivity.java
+++ b/exampleAdvancedCameraCapturer/src/main/java/com/twilio/video/examples/advancedcameracapturer/AdvancedCameraCapturerActivity.java
@@ -19,7 +19,6 @@ import android.widget.Toast;
 
 import com.twilio.video.CameraCapturer;
 import com.twilio.video.CameraParameterUpdater;
-import com.twilio.video.LocalMedia;
 import com.twilio.video.LocalVideoTrack;
 import com.twilio.video.VideoView;
 
@@ -35,7 +34,6 @@ import com.twilio.video.VideoView;
 public class AdvancedCameraCapturerActivity extends Activity {
     private static final int CAMERA_PERMISSION_REQUEST_CODE = 100;
 
-    private LocalMedia localMedia;
     private VideoView videoView;
     private Button toggleFlashButton;
     private Button takePictureButton;
@@ -105,7 +103,6 @@ public class AdvancedCameraCapturerActivity extends Activity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_advanced_camera_capturer);
 
-        localMedia = LocalMedia.create(this);
         videoView = (VideoView) findViewById(R.id.video_view);
         toggleFlashButton = (Button) findViewById(R.id.toggle_flash_button);
         takePictureButton = (Button) findViewById(R.id.take_picture_button);
@@ -153,8 +150,10 @@ public class AdvancedCameraCapturerActivity extends Activity {
     @Override
     protected void onDestroy() {
         localVideoTrack.removeRenderer(videoView);
-        localMedia.removeVideoTrack(localVideoTrack);
-        localMedia.release();
+        if (localVideoTrack != null) {
+            localVideoTrack.release();
+            localVideoTrack = null;
+        }
         super.onDestroy();
     }
 
@@ -172,7 +171,7 @@ public class AdvancedCameraCapturerActivity extends Activity {
 
     private void addCameraVideo() {
         cameraCapturer = new CameraCapturer(this, CameraCapturer.CameraSource.BACK_CAMERA);
-        localVideoTrack = localMedia.addVideoTrack(true, cameraCapturer);
+        localVideoTrack = LocalVideoTrack.create(this, true, cameraCapturer);
         localVideoTrack.addRenderer(videoView);
         toggleFlashButton.setOnClickListener(toggleFlashButtonClickListener);
         takePictureButton.setOnClickListener(takePictureButtonClickListener);

--- a/exampleCustomVideoCapturer/build.gradle
+++ b/exampleCustomVideoCapturer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.0.0-beta16"
+    compile "com.twilio:video-android:1.0.0-beta17"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleCustomVideoCapturer/src/main/java/com/twilio/video/examples/customcapturer/CustomCapturerVideoActivity.java
+++ b/exampleCustomVideoCapturer/src/main/java/com/twilio/video/examples/customcapturer/CustomCapturerVideoActivity.java
@@ -5,7 +5,6 @@ import android.os.Bundle;
 import android.widget.Chronometer;
 import android.widget.LinearLayout;
 
-import com.twilio.video.LocalMedia;
 import com.twilio.video.LocalVideoTrack;
 import com.twilio.video.VideoView;
 
@@ -15,7 +14,6 @@ import com.twilio.video.VideoView;
  * {@link VideoView} below.
  */
 public class CustomCapturerVideoActivity extends Activity {
-    private LocalMedia localMedia;
     private LinearLayout capturedView;
     private VideoView videoView;
     private Chronometer timerView;
@@ -26,23 +24,22 @@ public class CustomCapturerVideoActivity extends Activity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_custom_capturer);
 
-        localMedia = LocalMedia.create(this);
         capturedView = (LinearLayout) findViewById(R.id.captured_view);
         videoView = (VideoView) findViewById(R.id.video_view);
         timerView = (Chronometer) findViewById(R.id.timer_view);
         timerView.start();
 
         // Once added we should see our linear layout rendered live below
-        localVideoTrack = localMedia.addVideoTrack(true, new ViewCapturer(capturedView));
+        localVideoTrack = LocalVideoTrack.create(this, true, new ViewCapturer(capturedView));
         localVideoTrack.addRenderer(videoView);
     }
 
     @Override
     protected void onDestroy() {
         localVideoTrack.removeRenderer(videoView);
-        localMedia.removeVideoTrack(localVideoTrack);
+        localVideoTrack.release();
+        localVideoTrack = null;
         timerView.stop();
-        localMedia.release();
         super.onDestroy();
     }
 }

--- a/exampleCustomVideoRenderer/build.gradle
+++ b/exampleCustomVideoRenderer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.0.0-beta16"
+    compile "com.twilio:video-android:1.0.0-beta17"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleCustomVideoRenderer/src/main/java/com/twilio/video/examples/customrenderer/CustomRendererVideoActivity.java
+++ b/exampleCustomVideoRenderer/src/main/java/com/twilio/video/examples/customrenderer/CustomRendererVideoActivity.java
@@ -13,7 +13,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.twilio.video.CameraCapturer;
-import com.twilio.video.LocalMedia;
 import com.twilio.video.LocalVideoTrack;
 import com.twilio.video.VideoView;
 
@@ -25,7 +24,6 @@ import com.twilio.video.VideoView;
 public class CustomRendererVideoActivity extends Activity {
     private static final int CAMERA_PERMISSION_REQUEST_CODE = 100;
 
-    private LocalMedia localMedia;
     private VideoView localVideoView;
     private ImageView snapshotImageView;
     private TextView tapForSnapshotTextView;
@@ -37,7 +35,6 @@ public class CustomRendererVideoActivity extends Activity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_custom_renderer);
 
-        localMedia = LocalMedia.create(this);
         localVideoView = (VideoView) findViewById(R.id.local_video);
         snapshotImageView = (ImageView) findViewById(R.id.image_view);
         tapForSnapshotTextView = (TextView) findViewById(R.id.tap_video_snapshot);
@@ -77,13 +74,13 @@ public class CustomRendererVideoActivity extends Activity {
     protected void onDestroy() {
         localVideoTrack.removeRenderer(localVideoView);
         localVideoTrack.removeRenderer(snapshotVideoRenderer);
-        localMedia.removeVideoTrack(localVideoTrack);
-        localMedia.release();
+        localVideoTrack.release();
+        localVideoTrack = null;
         super.onDestroy();
     }
 
     private void addVideo() {
-        localVideoTrack = localMedia.addVideoTrack(true, new CameraCapturer(this,
+        localVideoTrack = LocalVideoTrack.create(this, true, new CameraCapturer(this,
                 CameraCapturer.CameraSource.FRONT_CAMERA, null));
         snapshotVideoRenderer = new SnapshotVideoRenderer(snapshotImageView);
         localVideoTrack.addRenderer(localVideoView);

--- a/exampleCustomVideoRenderer/src/main/java/com/twilio/video/examples/customrenderer/SnapshotVideoRenderer.java
+++ b/exampleCustomVideoRenderer/src/main/java/com/twilio/video/examples/customrenderer/SnapshotVideoRenderer.java
@@ -12,6 +12,9 @@ import android.widget.ImageView;
 import com.twilio.video.I420Frame;
 import com.twilio.video.VideoRenderer;
 
+import org.webrtc.RendererCommon;
+import org.webrtc.YuvConverter;
+
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -36,7 +39,14 @@ public class SnapshotVideoRenderer implements VideoRenderer {
     public void renderFrame(final I420Frame i420Frame) {
         // Capture bitmap and post to main thread
         if (snapshotRequsted.compareAndSet(true, false)) {
-            final Bitmap bitmap = captureBitmap(i420Frame);
+            /*
+             * I420Frame can be represented as texture or an in-memory buffer. yuvPlanes is not
+             * null and textureId is zero when frame is represented in memory and yuvPlanes is
+             * null textureId is a non zero value when the frame is represented as a texture.
+             */
+            final Bitmap bitmap = i420Frame.yuvPlanes == null ?
+                    captureBitmapFromTexture(i420Frame) :
+                    captureBitmapFromYuvFrame(i420Frame);
             handler.post(new Runnable() {
                 @Override
                 public void run() {
@@ -59,8 +69,85 @@ public class SnapshotVideoRenderer implements VideoRenderer {
         snapshotRequsted.set(true);
     }
 
-    private Bitmap captureBitmap(I420Frame i420Frame) {
-        YuvImage yuvImage = i420ToYuvImage(i420Frame);
+    private Bitmap captureBitmapFromTexture(I420Frame i420Frame) {
+        int width = i420Frame.rotatedWidth();
+        int height = i420Frame.rotatedHeight();
+        int outputFrameSize = width * height * 3 / 2;
+        ByteBuffer outputFrameBuffer = ByteBuffer.allocateDirect(outputFrameSize);
+        final float frameAspectRatio = (float) i420Frame.rotatedWidth() /
+                (float) i420Frame.rotatedHeight();
+        final float[] rotatedSamplingMatrix =
+                RendererCommon.rotateTextureMatrix(i420Frame.samplingMatrix,
+                        i420Frame.rotationDegree);
+        final float[] layoutMatrix = RendererCommon.getLayoutMatrix(false,
+                frameAspectRatio,
+                (float) width / height);
+        final float[] texMatrix = RendererCommon.multiplyMatrices(rotatedSamplingMatrix,
+                layoutMatrix);
+        /*
+         * YuvConverter must be instantiated on a thread that has an active EGL context. We know
+         * that renderFrame is called from the correct render thread therefore
+         * we defer instantiation of the converter until frame arrives.
+         */
+        YuvConverter yuvConverter = new YuvConverter();
+        yuvConverter.convert(outputFrameBuffer,
+                width,
+                height,
+                width,
+                i420Frame.textureId,
+                texMatrix);
+
+        // Now we need to unpack the YUV data into planes
+        byte[] data = outputFrameBuffer.array();
+        int offset = outputFrameBuffer.arrayOffset();
+        int stride = width;
+        ByteBuffer[] yuvPlanes = new ByteBuffer[] {
+                ByteBuffer.allocateDirect(width * height),
+                ByteBuffer.allocateDirect(width * height / 4),
+                ByteBuffer.allocateDirect(width * height / 4)
+        };
+        int[] yuvStrides = new int[] {
+                width,
+                (width + 1) / 2,
+                (width + 1) / 2
+        };
+
+        // Write Y
+        yuvPlanes[0].put(data, offset, width * height);
+
+        // Write U
+        for (int r = height ; r < height * 3 / 2; ++r) {
+            yuvPlanes[1].put(data, offset + r * stride, stride / 2);
+        }
+
+        // Write V
+        for (int r = height ; r < height * 3 / 2 ; ++r) {
+            yuvPlanes[2].put(data, offset + r * stride + stride / 2, stride / 2);
+        }
+
+        // Convert the YuvImage
+        YuvImage yuvImage = i420ToYuvImage(yuvPlanes, yuvStrides, width, height);
+
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        Rect rect = new Rect(0, 0, yuvImage.getWidth(), yuvImage.getHeight());
+
+        // Compress YuvImage to jpeg
+        yuvImage.compressToJpeg(rect, 100, stream);
+
+        // Convert jpeg to Bitmap
+        byte[] imageBytes = stream.toByteArray();
+
+        // Release YUV Converter
+        yuvConverter.release();
+
+        return BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.length);
+    }
+
+    private Bitmap captureBitmapFromYuvFrame(I420Frame i420Frame) {
+        YuvImage yuvImage = i420ToYuvImage(i420Frame.yuvPlanes,
+                i420Frame.yuvStrides,
+                i420Frame.width,
+                i420Frame.height);
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
         Rect rect = new Rect(0, 0, yuvImage.getWidth(), yuvImage.getHeight());
 
@@ -80,58 +167,64 @@ public class SnapshotVideoRenderer implements VideoRenderer {
         return bitmap;
     }
 
-    private YuvImage i420ToYuvImage(I420Frame i420Frame) {
-        if (i420Frame.yuvStrides[0] != i420Frame.width) {
-            return fastI420ToYuvImage(i420Frame);
+    private YuvImage i420ToYuvImage(ByteBuffer[] yuvPlanes,
+                                    int[] yuvStrides,
+                                    int width,
+                                    int height) {
+        if (yuvStrides[0] != width) {
+            return fastI420ToYuvImage(yuvPlanes, yuvStrides, width, height);
         }
-        if (i420Frame.yuvStrides[1] != i420Frame.width / 2) {
-            return fastI420ToYuvImage(i420Frame);
+        if (yuvStrides[1] != width / 2) {
+            return fastI420ToYuvImage(yuvPlanes, yuvStrides, width, height);
         }
-        if (i420Frame.yuvStrides[2] != i420Frame.width / 2) {
-            return fastI420ToYuvImage(i420Frame);
+        if (yuvStrides[2] != width / 2) {
+            return fastI420ToYuvImage(yuvPlanes, yuvStrides, width, height);
         }
 
-        byte[] bytes = new byte[i420Frame.yuvStrides[0] * i420Frame.height +
-                i420Frame.yuvStrides[1] * i420Frame.height / 2 +
-                i420Frame.yuvStrides[2] * i420Frame.height / 2];
-        ByteBuffer tmp = ByteBuffer.wrap(bytes, 0, i420Frame.width * i420Frame.height);
-        copyPlane(i420Frame.yuvPlanes[0], tmp);
+        byte[] bytes = new byte[yuvStrides[0] * height +
+                yuvStrides[1] * height / 2 +
+                yuvStrides[2] * height / 2];
+        ByteBuffer tmp = ByteBuffer.wrap(bytes, 0, width * height);
+        copyPlane(yuvPlanes[0], tmp);
 
-        byte[] tmpBytes = new byte[i420Frame.width / 2 * i420Frame.height / 2];
-        tmp = ByteBuffer.wrap(tmpBytes, 0, i420Frame.width / 2 * i420Frame.height / 2);
+        byte[] tmpBytes = new byte[width / 2 * height / 2];
+        tmp = ByteBuffer.wrap(tmpBytes, 0, width / 2 * height / 2);
 
-        copyPlane(i420Frame.yuvPlanes[2], tmp);
-        for (int row = 0 ; row < i420Frame.height / 2 ; row++) {
-            for (int col = 0 ; col < i420Frame.width / 2 ; col++) {
-                bytes[i420Frame.width * i420Frame.height + row * i420Frame.width + col * 2]
-                        = tmpBytes[row * i420Frame.width / 2 + col];
+        copyPlane(yuvPlanes[2], tmp);
+        for (int row = 0 ; row < height / 2 ; row++) {
+            for (int col = 0 ; col < width / 2 ; col++) {
+                bytes[width * height + row * width + col * 2]
+                        = tmpBytes[row * width / 2 + col];
             }
         }
-        copyPlane(i420Frame.yuvPlanes[1], tmp);
-        for (int row = 0 ; row < i420Frame.height / 2 ; row++) {
-            for (int col = 0 ; col < i420Frame.width / 2 ; col++) {
-                bytes[i420Frame.width * i420Frame.height + row * i420Frame.width + col * 2 + 1] =
-                        tmpBytes[row * i420Frame.width / 2 + col];
+        copyPlane(yuvPlanes[1], tmp);
+        for (int row = 0 ; row < height / 2 ; row++) {
+            for (int col = 0 ; col < width / 2 ; col++) {
+                bytes[width * height + row * width + col * 2 + 1] =
+                        tmpBytes[row * width / 2 + col];
             }
         }
-        return new YuvImage(bytes, NV21, i420Frame.width, i420Frame.height, null);
+        return new YuvImage(bytes, NV21, width, height, null);
     }
 
-    private YuvImage fastI420ToYuvImage(I420Frame i420Frame) {
-        byte[] bytes = new byte[i420Frame.width * i420Frame.height * 3 / 2];
+    private YuvImage fastI420ToYuvImage(ByteBuffer[] yuvPlanes,
+                                        int[] yuvStrides,
+                                        int width,
+                                        int height) {
+        byte[] bytes = new byte[width * height * 3 / 2];
         int i = 0;
-        for (int row = 0 ; row < i420Frame.height ; row++) {
-            for (int col = 0 ; col < i420Frame.width ; col++) {
-                bytes[i++] = i420Frame.yuvPlanes[0].get(col + row * i420Frame.yuvStrides[0]);
+        for (int row = 0 ; row < height ; row++) {
+            for (int col = 0 ; col < width ; col++) {
+                bytes[i++] = yuvPlanes[0].get(col + row * yuvStrides[0]);
             }
         }
-        for (int row = 0 ; row < i420Frame.height / 2 ; row++) {
-            for (int col = 0 ; col < i420Frame.width / 2; col++) {
-                bytes[i++] = i420Frame.yuvPlanes[2].get(col + row * i420Frame.yuvStrides[2]);
-                bytes[i++] = i420Frame.yuvPlanes[1].get(col + row * i420Frame.yuvStrides[1]);
+        for (int row = 0 ; row < height / 2 ; row++) {
+            for (int col = 0 ; col < width / 2; col++) {
+                bytes[i++] = yuvPlanes[2].get(col + row * yuvStrides[2]);
+                bytes[i++] = yuvPlanes[1].get(col + row * yuvStrides[1]);
             }
         }
-        return new YuvImage(bytes, NV21, i420Frame.width, i420Frame.height, null);
+        return new YuvImage(bytes, NV21, width, height, null);
     }
 
     private void copyPlane(ByteBuffer src, ByteBuffer dst) {

--- a/exampleScreenCapturer/build.gradle
+++ b/exampleScreenCapturer/build.gradle
@@ -26,7 +26,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.0.0-beta16"
+    compile "com.twilio:video-android:1.0.0-beta17"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleScreenCapturer/src/main/java/com/twilio/video/examples/screencapturer/ScreenCapturerActivity.java
+++ b/exampleScreenCapturer/src/main/java/com/twilio/video/examples/screencapturer/ScreenCapturerActivity.java
@@ -12,7 +12,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.Toast;
 
-import com.twilio.video.LocalMedia;
 import com.twilio.video.LocalVideoTrack;
 import com.twilio.video.ScreenCapturer;
 import com.twilio.video.VideoView;
@@ -24,7 +23,6 @@ public class ScreenCapturerActivity extends AppCompatActivity {
     private static final String TAG = "ScreenCapturer";
     private static final int REQUEST_MEDIA_PROJECTION = 100;
 
-    private LocalMedia localMedia;
     private VideoView localVideoView;
     private LocalVideoTrack screenVideoTrack;
     private ScreenCapturer screenCapturer;
@@ -49,8 +47,6 @@ public class ScreenCapturerActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_screen_capturer);
         localVideoView = (VideoView) findViewById(R.id.local_video);
-
-        localMedia = LocalMedia.create(this);
     }
 
     @Override
@@ -113,7 +109,7 @@ public class ScreenCapturerActivity extends AppCompatActivity {
     }
 
     private void startScreenCapture() {
-        screenVideoTrack = localMedia.addVideoTrack(true, screenCapturer);
+        screenVideoTrack = LocalVideoTrack.create(this, true, screenCapturer);
         screenCaptureMenuItem.setIcon(R.drawable.ic_stop_screen_share_white_24dp);
         screenCaptureMenuItem.setTitle(R.string.stop_screen_share);
 
@@ -122,22 +118,21 @@ public class ScreenCapturerActivity extends AppCompatActivity {
     }
 
     private void stopScreenCapture() {
-        localVideoView.setVisibility(View.INVISIBLE);
-        localMedia.removeVideoTrack(screenVideoTrack);
-
-        screenCaptureMenuItem.setIcon(R.drawable.ic_screen_share_white_24dp);
-        screenCaptureMenuItem.setTitle(R.string.share_screen);
-        screenVideoTrack.removeRenderer(localVideoView);
+        if (screenVideoTrack != null) {
+            screenVideoTrack.removeRenderer(localVideoView);
+            screenVideoTrack.release();
+            screenVideoTrack = null;
+            localVideoView.setVisibility(View.INVISIBLE);
+            screenCaptureMenuItem.setIcon(R.drawable.ic_screen_share_white_24dp);
+            screenCaptureMenuItem.setTitle(R.string.share_screen);
+        }
     }
 
     @Override
     protected void onDestroy() {
-        if (localMedia != null) {
-            if (screenVideoTrack != null) {
-                localMedia.removeVideoTrack(screenVideoTrack);
-            }
-            localMedia.release();
-            localMedia = null;
+        if (screenVideoTrack != null) {
+            screenVideoTrack.release();
+            screenVideoTrack = null;
         }
         super.onDestroy();
     }

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
 
     compile 'com.koushikdutta.ion:ion:2.1.7'
-    compile "com.twilio:video-android:1.0.0-beta16"
+    compile "com.twilio:video-android:1.0.0-beta17"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -21,6 +21,7 @@ import android.widget.Toast;
 import com.google.gson.JsonObject;
 import com.koushikdutta.async.future.FutureCallback;
 import com.koushikdutta.ion.Ion;
+import com.twilio.video.LocalParticipant;
 import com.twilio.video.RoomState;
 import com.twilio.video.Video;
 import com.twilio.video.VideoRenderer;
@@ -32,14 +33,13 @@ import com.twilio.video.CameraCapturer;
 import com.twilio.video.CameraCapturer.CameraSource;
 import com.twilio.video.ConnectOptions;
 import com.twilio.video.LocalAudioTrack;
-import com.twilio.video.LocalMedia;
 import com.twilio.video.LocalVideoTrack;
-import com.twilio.video.Media;
 import com.twilio.video.Participant;
 import com.twilio.video.Room;
 import com.twilio.video.VideoTrack;
 import com.twilio.video.VideoView;
 
+import java.util.Collections;
 import java.util.Map;
 
 public class VideoActivity extends AppCompatActivity {
@@ -62,6 +62,7 @@ public class VideoActivity extends AppCompatActivity {
      * A Room represents communication between a local participant and one or more participants.
      */
     private Room room;
+    private LocalParticipant localParticipant;
 
     /*
      * A VideoView receives frames from a local or remote video track and renders them
@@ -75,7 +76,6 @@ public class VideoActivity extends AppCompatActivity {
      */
     private TextView videoStatusTextView;
     private CameraCapturer cameraCapturer;
-    private LocalMedia localMedia;
     private LocalAudioTrack localAudioTrack;
     private LocalVideoTrack localVideoTrack;
     private FloatingActionButton connectActionFab;
@@ -120,7 +120,7 @@ public class VideoActivity extends AppCompatActivity {
         if (!checkPermissionForCameraAndMicrophone()) {
             requestPermissionForCameraAndMicrophone();
         } else {
-            createLocalMedia();
+            createAudioAndVideoTracks();
             setAccessToken();
         }
 
@@ -142,7 +142,7 @@ public class VideoActivity extends AppCompatActivity {
             }
 
             if (cameraAndMicPermissionGranted) {
-                createLocalMedia();
+                createAudioAndVideoTracks();
                 setAccessToken();
             } else {
                 Toast.makeText(this,
@@ -156,25 +156,38 @@ public class VideoActivity extends AppCompatActivity {
     protected  void onResume() {
         super.onResume();
         /*
-         * If the local video track was removed when the app was put in the background, add it back.
+         * If the local video track was released when the app was put in the background, recreate.
          */
-        if (localMedia != null && localVideoTrack == null) {
-            localVideoTrack = localMedia.addVideoTrack(true, cameraCapturer);
+        if (localVideoTrack == null) {
+            localVideoTrack = LocalVideoTrack.create(this, true, cameraCapturer);
             localVideoTrack.addRenderer(localVideoView);
+
+            /*
+             * If connected to a Room then share the local video track.
+             */
+            if (localParticipant != null) {
+                localParticipant.addVideoTrack(localVideoTrack);
+            }
         }
     }
 
     @Override
     protected void onPause() {
         /*
-         * Remove the local video track before going in the background. This ensures that the
+         * Release the local video track before going in the background. This ensures that the
          * camera can be used by other applications while this app is in the background.
-         *
-         * If this local video track is being shared in a Room, participants will be notified
-         * that the track has been removed.
          */
-        if (localMedia != null && localVideoTrack != null) {
-            localMedia.removeVideoTrack(localVideoTrack);
+        if (localVideoTrack != null) {
+            /*
+             * If this local video track is being shared in a Room, remove from local
+             * participant before releasing the video track. Participants will be notified that
+             * the track has been removed.
+             */
+            if (localParticipant != null) {
+                localParticipant.removeVideoTrack(localVideoTrack);
+            }
+
+            localVideoTrack.release();
             localVideoTrack = null;
         }
         super.onPause();
@@ -192,11 +205,16 @@ public class VideoActivity extends AppCompatActivity {
         }
 
         /*
-         * Release the local media ensuring any memory allocated to audio or video is freed.
+         * Release the local audio and video tracks ensuring any memory allocated to audio
+         * or video is freed.
          */
-        if (localMedia != null) {
-            localMedia.release();
-            localMedia = null;
+        if (localAudioTrack != null) {
+            localAudioTrack.release();
+            localAudioTrack = null;
+        }
+        if (localVideoTrack != null) {
+            localVideoTrack.release();
+            localVideoTrack = null;
         }
 
         super.onDestroy();
@@ -224,15 +242,13 @@ public class VideoActivity extends AppCompatActivity {
         }
     }
 
-    private void createLocalMedia() {
-        localMedia = LocalMedia.create(this);
-
+    private void createAudioAndVideoTracks() {
         // Share your microphone
-        localAudioTrack = localMedia.addAudioTrack(true);
+        localAudioTrack = LocalAudioTrack.create(this, true);
 
         // Share your camera
         cameraCapturer = new CameraCapturer(this, CameraSource.FRONT_CAMERA);
-        localVideoTrack = localMedia.addVideoTrack(true, cameraCapturer);
+        localVideoTrack = LocalVideoTrack.create(this, true, cameraCapturer);
         primaryVideoView.setMirror(true);
         localVideoTrack.addRenderer(primaryVideoView);
         localVideoView = primaryVideoView;
@@ -249,16 +265,29 @@ public class VideoActivity extends AppCompatActivity {
 
     private void connectToRoom(String roomName) {
         setAudioFocus(true);
-        ConnectOptions connectOptions = new ConnectOptions.Builder(accessToken)
-                .roomName(roomName)
-                .localMedia(localMedia)
-                .build();
-        room = Video.connect(this, connectOptions, roomListener());
+        ConnectOptions.Builder connectOptionsBuilder = new ConnectOptions.Builder(accessToken)
+                .roomName(roomName);
+
+        /*
+         * Add local audio track to connect options to share with participants.
+         */
+        if (localAudioTrack != null) {
+            connectOptionsBuilder
+                    .audioTracks(Collections.singletonList(localAudioTrack));
+        }
+
+        /*
+         * Add local video track to connect options to share with participants.
+         */
+        if (localVideoTrack != null) {
+            connectOptionsBuilder.videoTracks(Collections.singletonList(localVideoTrack));
+        }
+        room = Video.connect(this, connectOptionsBuilder.build(), roomListener());
         setDisconnectAction();
     }
 
     /*
-     * The initial state when there is no active conversation.
+     * The initial state when there is no active room.
      */
     private void intializeUI() {
         connectActionFab.setImageDrawable(ContextCompat.getDrawable(this,
@@ -313,14 +342,14 @@ public class VideoActivity extends AppCompatActivity {
         /*
          * Add participant renderer
          */
-        if (participant.getMedia().getVideoTracks().size() > 0) {
-            addParticipantVideo(participant.getMedia().getVideoTracks().get(0));
+        if (participant.getVideoTracks().size() > 0) {
+            addParticipantVideo(participant.getVideoTracks().get(0));
         }
 
         /*
-         * Start listening for participant media events
+         * Start listening for participant events
          */
-        participant.getMedia().setListener(mediaListener());
+        participant.setListener(participantListener());
     }
 
     /*
@@ -355,10 +384,10 @@ public class VideoActivity extends AppCompatActivity {
         /*
          * Remove participant renderer
          */
-        if (participant.getMedia().getVideoTracks().size() > 0) {
-            removeParticipantVideo(participant.getMedia().getVideoTracks().get(0));
+        if (participant.getVideoTracks().size() > 0) {
+            removeParticipantVideo(participant.getVideoTracks().get(0));
         }
-        participant.getMedia().setListener(null);
+        participant.setListener(null);
         moveLocalVideoToPrimaryView();
     }
 
@@ -384,6 +413,7 @@ public class VideoActivity extends AppCompatActivity {
         return new Room.Listener() {
             @Override
             public void onConnected(Room room) {
+                localParticipant = room.getLocalParticipant();
                 videoStatusTextView.setText("Connected to " + room.getName());
                 setTitle(room.getName());
 
@@ -400,6 +430,7 @@ public class VideoActivity extends AppCompatActivity {
 
             @Override
             public void onDisconnected(Room room, TwilioException e) {
+                localParticipant = null;
                 videoStatusTextView.setText("Disconnected from " + room.getName());
                 VideoActivity.this.room = null;
                 // Only reinitialize the UI if disconnect was not called from onDestroy()
@@ -441,48 +472,47 @@ public class VideoActivity extends AppCompatActivity {
         };
     }
 
-    private Media.Listener mediaListener() {
-        return new Media.Listener() {
-
+    private Participant.Listener participantListener() {
+        return new Participant.Listener() {
             @Override
-            public void onAudioTrackAdded(Media media, AudioTrack audioTrack) {
+            public void onAudioTrackAdded(Participant participant, AudioTrack audioTrack) {
                 videoStatusTextView.setText("onAudioTrackAdded");
             }
 
             @Override
-            public void onAudioTrackRemoved(Media media, AudioTrack audioTrack) {
+            public void onAudioTrackRemoved(Participant participant, AudioTrack audioTrack) {
                 videoStatusTextView.setText("onAudioTrackRemoved");
             }
 
             @Override
-            public void onVideoTrackAdded(Media media, VideoTrack videoTrack) {
+            public void onVideoTrackAdded(Participant participant, VideoTrack videoTrack) {
                 videoStatusTextView.setText("onVideoTrackAdded");
                 addParticipantVideo(videoTrack);
             }
 
             @Override
-            public void onVideoTrackRemoved(Media media, VideoTrack videoTrack) {
+            public void onVideoTrackRemoved(Participant participant, VideoTrack videoTrack) {
                 videoStatusTextView.setText("onVideoTrackRemoved");
                 removeParticipantVideo(videoTrack);
             }
 
             @Override
-            public void onAudioTrackEnabled(Media media, AudioTrack audioTrack) {
+            public void onAudioTrackEnabled(Participant participant, AudioTrack audioTrack) {
 
             }
 
             @Override
-            public void onAudioTrackDisabled(Media media, AudioTrack audioTrack) {
+            public void onAudioTrackDisabled(Participant participant, AudioTrack audioTrack) {
 
             }
 
             @Override
-            public void onVideoTrackEnabled(Media media, VideoTrack videoTrack) {
+            public void onVideoTrackEnabled(Participant participant, VideoTrack videoTrack) {
 
             }
 
             @Override
-            public void onVideoTrackDisabled(Media media, VideoTrack videoTrack) {
+            public void onVideoTrackDisabled(Participant participant, VideoTrack videoTrack) {
 
             }
         };

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -417,8 +417,8 @@ public class VideoActivity extends AppCompatActivity {
                 videoStatusTextView.setText("Connected to " + room.getName());
                 setTitle(room.getName());
 
-                for (Map.Entry<String, Participant> entry : room.getParticipants().entrySet()) {
-                    addParticipant(entry.getValue());
+                for (Participant participant : room.getParticipants()) {
+                    addParticipant(participant);
                     break;
                 }
             }


### PR DESCRIPTION
Improvements

- Replaced `LocalMedia` class with Track factories for `LocalVideoTrack` and `LocalAudioTrack`

Working with `LocalVideoTrack` and `LocalAudioTrack` before 1.0.0-beta17

    // Create LocalMedia
    LocalMedia localMedia = LocalMedia.create(context);
    LocalVideoTrack localVideoTrack = localMedia.addVideoTrack(true, videoCapturer);
    LocalAudioTrack localAudioTrack = localMedia.addAudioTrack(true);

    ...

    // Destroy LocalMedia to free native memory resources
    localMedia.release();

Working with `LocalVideoTrack` and `LocalAudioTrack` now

    // Create Tracks
    LocalVideoTrack localVideoTrack = LocalVideoTrack.create(context, true, videoCapturer);
    LocalAudioTrack localAudioTrack = LocalAudioTrack.create(context, true);

    ...

    // Destroy Tracks to free native memory resources
    localVideoTrack.release();
    localAudioTrack.release();

- The `ConnectOptions.Builder` now takes a `List<LocalAudioTrack>` and `List<LocalVideoTrack>` instead of `LocalMedia`

Providing `LocalVideoTrack` and `LocalAudioTrack` before 1.0.0-beta17

    LocalMedia localMedia = LocalMedia.create(context);
    LocalVideoTrack localVideoTrack = localMedia.addVideoTrack(true, videoCapturer);
    LocalAudioTrack localAudioTrack = localMedia.addAudioTrack(true);

    ConnectOptions connectOptions = new ConnectOptions.Builder(accessToken)
        .roomName(roomName)
        .localMedia(localMedia)
        .build();
    VideoClient.connect(context, connectOptions, roomListener);

Providing `LocalVideoTrack` and `LocalAudioTrack` now

    List<LocalVideoTrack> localAudioTracks =
                new ArrayList<LocalVideoTrack>(){{ add(localVideoTrack); }};
    List<LocalAudioTrack> localVideoTracks =
                new ArrayList<LocalAudioTrack>(){{ add(localAudioTrack); }};

    ConnectOptions connectOptions = new ConnectOptions.Builder(accessToken)
        .roomName(roomName)
        .audioTracks(localAudioTracks)
        .videoTracks(localVideoTracks)
        .build();
    VideoClient.connect(context, connectOptions, roomListener);
- Methods `getVideoTracks()` and `getAudioTracks()` moved from `LocalMedia` and `Media` to `LocalParticipant` and `Participant`
- Removed `Media` from `Participant` and migrated `Media.Listener` to `Participant.Listener`.
`AudioTrack` and `VideoTrack` events are raised with the corresponding `Participant` instance.
This allows you to create tracks while connected to a `Room` without immediately adding them to the connected `Room`
- Improved hardware accelerated decoding through the use of surface textures.
- Added `textureId` and `samplingMatrix` fields to `I420Frame` so implementations of `VideoRenderer`
can extract YUV data from frame represented as texture.
- Exposed `org.webrtc.YuvConverter` to facilitate converting a texture to an in memory YUV buffer.
- Invoke `ScreenCapturer.Listener` callbacks on the thread `ScreenCapturer` is created on.
- Fixed an issue where the ConnectivityReceiver was causing a reconnect when connecting to a `Room` for the first time occasionally leading to a 53001 error `onConnectFailure` response.
- `Room#getParticipants` returns `List<Participant>` instead of `Map<String, Participant>`.

Bug Fixes

- On Nexus 9 device, intermittent high decoding times results in delayed video. [#95](https://github.com/twilio/video-quickstart-android/issues/95)
- Unsatisfied link errors for `org.webrtc.voiceengine.WebRtcAudioManager` and `org.webrtc.voiceengine.WebRtcAudioTrack` construction. [#102](https://github.com/twilio/video-quickstart-android/issues/102)
- VideoTrack isEnabled() returning wrong state [#104](https://github.com/twilio/video-quickstart-android/issues/104)
