### PR TITLE
1.1.0 release

### DIFF
--- a/exampleAdvancedCameraCapturer/build.gradle
+++ b/exampleAdvancedCameraCapturer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.0.2"
+    compile "com.twilio:video-android:1.1.0"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleCustomVideoCapturer/build.gradle
+++ b/exampleCustomVideoCapturer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.0.2"
+    compile "com.twilio:video-android:1.1.0"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleCustomVideoRenderer/build.gradle
+++ b/exampleCustomVideoRenderer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.0.2"
+    compile "com.twilio:video-android:1.1.0"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleScreenCapturer/build.gradle
+++ b/exampleScreenCapturer/build.gradle
@@ -26,7 +26,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.0.2"
+    compile "com.twilio:video-android:1.1.0"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleVideoInvite/build.gradle
+++ b/exampleVideoInvite/build.gradle
@@ -34,7 +34,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 
-    compile "com.twilio:video-android:1.0.0"
+    compile "com.twilio:video-android:1.1.0"
     compile "com.google.firebase:firebase-messaging:10.0.1"
     compile 'com.squareup.retrofit2:retrofit:2.0.0-beta4'
     compile 'com.squareup.okhttp3:logging-interceptor:3.6.0'

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -41,7 +41,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.0.2"
+    compile "com.twilio:video-android:1.1.0"
     compile 'com.koushikdutta.ion:ion:2.1.7'
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -29,7 +29,6 @@ import com.twilio.video.TwilioException;
 import com.twilio.video.quickstart.R;
 import com.twilio.video.quickstart.dialog.Dialog;
 import com.twilio.video.AudioTrack;
-import com.twilio.video.CameraCapturer;
 import com.twilio.video.CameraCapturer.CameraSource;
 import com.twilio.video.ConnectOptions;
 import com.twilio.video.LocalAudioTrack;
@@ -38,6 +37,7 @@ import com.twilio.video.Participant;
 import com.twilio.video.Room;
 import com.twilio.video.VideoTrack;
 import com.twilio.video.VideoView;
+import com.twilio.video.quickstart.util.CameraCapturerCompat;
 
 import java.util.Collections;
 
@@ -74,7 +74,7 @@ public class VideoActivity extends AppCompatActivity {
      * Android application UI elements
      */
     private TextView videoStatusTextView;
-    private CameraCapturer cameraCapturer;
+    private CameraCapturerCompat cameraCapturer;
     private LocalAudioTrack localAudioTrack;
     private LocalVideoTrack localVideoTrack;
     private FloatingActionButton connectActionFab;
@@ -159,7 +159,7 @@ public class VideoActivity extends AppCompatActivity {
          * If the local video track was released when the app was put in the background, recreate.
          */
         if (localVideoTrack == null && checkPermissionForCameraAndMicrophone()) {
-            localVideoTrack = LocalVideoTrack.create(this, true, cameraCapturer);
+            localVideoTrack = LocalVideoTrack.create(this, true, cameraCapturer.getVideoCapturer());
             localVideoTrack.addRenderer(localVideoView);
 
             /*
@@ -247,8 +247,8 @@ public class VideoActivity extends AppCompatActivity {
         localAudioTrack = LocalAudioTrack.create(this, true);
 
         // Share your camera
-        cameraCapturer = new CameraCapturer(this, CameraSource.FRONT_CAMERA);
-        localVideoTrack = LocalVideoTrack.create(this, true, cameraCapturer);
+        cameraCapturer = new CameraCapturerCompat(this, CameraSource.FRONT_CAMERA);
+        localVideoTrack = LocalVideoTrack.create(this, true, cameraCapturer.getVideoCapturer());
         primaryVideoView.setMirror(true);
         localVideoTrack.addRenderer(primaryVideoView);
         localVideoView = primaryVideoView;

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -74,7 +74,7 @@ public class VideoActivity extends AppCompatActivity {
      * Android application UI elements
      */
     private TextView videoStatusTextView;
-    private CameraCapturerCompat cameraCapturer;
+    private CameraCapturerCompat cameraCapturerCompat;
     private LocalAudioTrack localAudioTrack;
     private LocalVideoTrack localVideoTrack;
     private FloatingActionButton connectActionFab;
@@ -159,7 +159,7 @@ public class VideoActivity extends AppCompatActivity {
          * If the local video track was released when the app was put in the background, recreate.
          */
         if (localVideoTrack == null && checkPermissionForCameraAndMicrophone()) {
-            localVideoTrack = LocalVideoTrack.create(this, true, cameraCapturer.getVideoCapturer());
+            localVideoTrack = LocalVideoTrack.create(this, true, cameraCapturerCompat.getVideoCapturer());
             localVideoTrack.addRenderer(localVideoView);
 
             /*
@@ -247,8 +247,8 @@ public class VideoActivity extends AppCompatActivity {
         localAudioTrack = LocalAudioTrack.create(this, true);
 
         // Share your camera
-        cameraCapturer = new CameraCapturerCompat(this, CameraSource.FRONT_CAMERA);
-        localVideoTrack = LocalVideoTrack.create(this, true, cameraCapturer.getVideoCapturer());
+        cameraCapturerCompat = new CameraCapturerCompat(this, CameraSource.FRONT_CAMERA);
+        localVideoTrack = LocalVideoTrack.create(this, true, cameraCapturerCompat.getVideoCapturer());
         primaryVideoView.setMirror(true);
         localVideoTrack.addRenderer(primaryVideoView);
         localVideoView = primaryVideoView;
@@ -367,7 +367,7 @@ public class VideoActivity extends AppCompatActivity {
             localVideoTrack.removeRenderer(primaryVideoView);
             localVideoTrack.addRenderer(thumbnailVideoView);
             localVideoView = thumbnailVideoView;
-            thumbnailVideoView.setMirror(cameraCapturer.getCameraSource() ==
+            thumbnailVideoView.setMirror(cameraCapturerCompat.getCameraSource() ==
                     CameraSource.FRONT_CAMERA);
         }
     }
@@ -401,7 +401,7 @@ public class VideoActivity extends AppCompatActivity {
             thumbnailVideoView.setVisibility(View.GONE);
             localVideoTrack.addRenderer(primaryVideoView);
             localVideoView = primaryVideoView;
-            primaryVideoView.setMirror(cameraCapturer.getCameraSource() ==
+            primaryVideoView.setMirror(cameraCapturerCompat.getCameraSource() ==
                     CameraSource.FRONT_CAMERA);
         }
     }
@@ -570,9 +570,9 @@ public class VideoActivity extends AppCompatActivity {
         return new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (cameraCapturer != null) {
-                    CameraSource cameraSource = cameraCapturer.getCameraSource();
-                    cameraCapturer.switchCamera();
+                if (cameraCapturerCompat != null) {
+                    CameraSource cameraSource = cameraCapturerCompat.getCameraSource();
+                    cameraCapturerCompat.switchCamera();
                     if (thumbnailVideoView.getVisibility() == View.VISIBLE) {
                         thumbnailVideoView.setMirror(cameraSource == CameraSource.BACK_CAMERA);
                     } else {

--- a/quickstart/src/main/java/com/twilio/video/quickstart/util/CameraCapturerCompat.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/util/CameraCapturerCompat.java
@@ -1,0 +1,118 @@
+package com.twilio.video.quickstart.util;
+
+import android.content.Context;
+import android.util.Log;
+import android.util.Pair;
+
+import com.twilio.video.Camera2Capturer;
+import com.twilio.video.CameraCapturer;
+import com.twilio.video.VideoCapturer;
+
+import org.webrtc.Camera2Enumerator;
+
+/*
+ * Simple wrapper class that uses Camera2Capturer with supported devices.
+ */
+public class CameraCapturerCompat {
+    private static final String TAG = "CameraCapturerCompat";
+
+    private CameraCapturer camera1Capturer;
+    private Camera2Capturer camera2Capturer;
+    private Pair<CameraCapturer.CameraSource, String> frontCameraPair;
+    private Pair<CameraCapturer.CameraSource, String> backCameraPair;
+    private final Camera2Capturer.Listener camera2Listener = new Camera2Capturer.Listener() {
+        @Override
+        public void onFirstFrameAvailable() {
+            Log.i(TAG, "onFirstFrameAvailable");
+        }
+
+        @Override
+        public void onCameraSwitched(String newCameraId) {
+            Log.i(TAG, "onCameraSwitched: newCameraId = " + newCameraId);
+        }
+
+        @Override
+        public void onError(Camera2Capturer.Exception camera2CapturerException) {
+            Log.e(TAG, camera2CapturerException.getMessage());
+        }
+    };
+
+    public CameraCapturerCompat(Context context,
+                                CameraCapturer.CameraSource cameraSource) {
+        if (Camera2Capturer.isSupported(context)) {
+            setCameraPairs(context);
+            camera2Capturer = new Camera2Capturer(context,
+                    getCameraId(cameraSource),
+                    camera2Listener);
+        } else {
+            camera1Capturer = new CameraCapturer(context, cameraSource);
+        }
+    }
+
+    public CameraCapturer.CameraSource getCameraSource() {
+        if (usingCamera1()) {
+            return camera1Capturer.getCameraSource();
+        } else {
+            return getCameraSource(camera2Capturer.getCameraId());
+        }
+    }
+
+    public void switchCamera() {
+        if (usingCamera1()) {
+            camera1Capturer.switchCamera();
+        } else {
+            CameraCapturer.CameraSource cameraSource = getCameraSource(camera2Capturer
+                    .getCameraId());
+
+            if (cameraSource == CameraCapturer.CameraSource.FRONT_CAMERA) {
+                camera2Capturer.switchCamera(backCameraPair.second);
+            } else {
+                camera2Capturer.switchCamera(frontCameraPair.second);
+            }
+        }
+    }
+
+    /*
+     * This method is required because this class is not an implementation of VideoCapturer due to
+     * a shortcoming in the Video Android SDK.
+     */
+    public VideoCapturer getVideoCapturer() {
+        if (usingCamera1()) {
+            return camera1Capturer;
+        } else {
+            return camera2Capturer;
+        }
+    }
+
+    private boolean usingCamera1() {
+        return camera1Capturer != null;
+    }
+
+    private void setCameraPairs(Context context) {
+        Camera2Enumerator camera2Enumerator = new Camera2Enumerator(context);
+        for (String cameraId : camera2Enumerator.getDeviceNames()) {
+            if (camera2Enumerator.isFrontFacing(cameraId)) {
+                frontCameraPair = new Pair<>(CameraCapturer.CameraSource.FRONT_CAMERA, cameraId);
+            }
+            if (camera2Enumerator.isBackFacing(cameraId)) {
+                backCameraPair = new Pair<>(CameraCapturer.CameraSource.BACK_CAMERA, cameraId);
+            }
+        }
+    }
+
+    private String getCameraId(CameraCapturer.CameraSource cameraSource) {
+        if (frontCameraPair.first == cameraSource) {
+            return frontCameraPair.second;
+        } else {
+            return backCameraPair.second;
+        }
+    }
+
+    private CameraCapturer.CameraSource getCameraSource(String cameraId) {
+        if (frontCameraPair.second.equals(cameraId)) {
+            return frontCameraPair.first;
+        } else {
+            return backCameraPair.first;
+        }
+    }
+}


### PR DESCRIPTION
Updated each module to `1.1.0` and added `CameraCapturerCompat` to quickstart module. This class uses camera 1 or camera 2 API depending on device compatibility. Changelog entry in following section.

---

Improvements

- Moved signaling network traffic to port 443. 
- Added `Camera2Capturer`. `Camera2Capturer` uses `android.hardware.camera2` to implement 
a `VideoCapturer`. `Camera2Capturer` does not yet implement `takePicture` and the ability to modify 
camera parameters once `Camera2Capturer` is running.

Create `LocalVideoTrack` with `Camera2Capturer`

    
    // Check if device supports Camera2Capturer 
    if (Camera2Capturer.isSupported(context)) {
        // Use CameraManager.getCameraIdList() for a list of all available camera IDs
        String cameraId = "0";
        Camera2Capturer.Listener camera2Listener = new Camera2Capturer.Listener() {
                @Override
                public void onFirstFrameAvailable() {}

                @Override
                public void onCameraSwitched(String newCameraId) {}

                @Override
                public void onError(Camera2Capturer.Exception exception) {}
        }
        Camera2Capturer camera2Capturer = new Camera2Capturer(context, cameraId, camera2Listener);
        LocalVideoTrack = LocalVideoTrack.create(context, true, camera2Capturer);
    }
    
- This release adds Insights statistics collection, which reports RTP quality metrics back to 
Twilio. In the future, these statistics will be included in customer-facing reports visible in the 
Twilio Console. Insights collection is enabled by default, if you wish to disable it reference
the following snippet.


        ConnectOptions connectOptions = new ConnectOptions.Builder(token)
                .enableInsights(false)
                .build();

Bug Fixes

- Improved signaling connection retry logic. In the case of an error, the SDK will continue 
to retry with a backoff timer when errors are encountered.
- Fixed a bug in network handoff scenarios where the SDK was not handling the race condition 
if network lost or network changed event is received when a network changed event is being processed.
- Fixed bug where audio and video tracks were not available after `onParticipantDisconnected` was
invoked [#125](https://github.com/twilio/video-quickstart-android/issues/125)