### PR TITLE
Update to 1.1.1 release

### DIFF
--- a/exampleAdvancedCameraCapturer/build.gradle
+++ b/exampleAdvancedCameraCapturer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.1.0"
+    compile "com.twilio:video-android:1.1.1"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleCustomVideoCapturer/build.gradle
+++ b/exampleCustomVideoCapturer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.1.0"
+    compile "com.twilio:video-android:1.1.1"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleCustomVideoRenderer/build.gradle
+++ b/exampleCustomVideoRenderer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.1.0"
+    compile "com.twilio:video-android:1.1.1"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleScreenCapturer/build.gradle
+++ b/exampleScreenCapturer/build.gradle
@@ -26,7 +26,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.1.0"
+    compile "com.twilio:video-android:1.1.1"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleVideoInvite/build.gradle
+++ b/exampleVideoInvite/build.gradle
@@ -34,7 +34,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 
-    compile "com.twilio:video-android:1.1.0"
+    compile "com.twilio:video-android:1.1.1"
     compile "com.google.firebase:firebase-messaging:10.0.1"
     compile 'com.squareup.retrofit2:retrofit:2.0.0-beta4'
     compile 'com.squareup.okhttp3:logging-interceptor:3.6.0'

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -41,7 +41,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.1.0"
+    compile "com.twilio:video-android:1.1.1"
     compile 'com.koushikdutta.ion:ion:2.1.7'
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'


### PR DESCRIPTION
Bug Fixes

- Fixed bug in `VideoConstraints` logic where valid VideoCapturer video formats were ignored due to very strict checking of aspect ratios in WebRTC
- Fixed bug in Logger.java where setting certain LogLevel's did not print error logs 
- Fixed bug in `LocalVideoTrack` where FPS check was incorrectly marking a constraint as incompatible. [#127](https://github.com/twilio/video-quickstart-android/issues/127)
