### PR TITLE
Update to 1.2.0

### DIFF
--- a/exampleAdvancedCameraCapturer/build.gradle
+++ b/exampleAdvancedCameraCapturer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.1.1"
+    compile "com.twilio:video-android:1.2.0"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleCustomVideoCapturer/build.gradle
+++ b/exampleCustomVideoCapturer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.1.1"
+    compile "com.twilio:video-android:1.2.0"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleCustomVideoRenderer/build.gradle
+++ b/exampleCustomVideoRenderer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.1.1"
+    compile "com.twilio:video-android:1.2.0"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleScreenCapturer/build.gradle
+++ b/exampleScreenCapturer/build.gradle
@@ -26,7 +26,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.1.1"
+    compile "com.twilio:video-android:1.2.0"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleVideoInvite/build.gradle
+++ b/exampleVideoInvite/build.gradle
@@ -34,7 +34,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 
-    compile "com.twilio:video-android:1.1.1"
+    compile "com.twilio:video-android:1.2.0"
     compile "com.google.firebase:firebase-messaging:10.0.1"
     compile 'com.squareup.retrofit2:retrofit:2.0.0-beta4'
     compile 'com.squareup.okhttp3:logging-interceptor:3.6.0'

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -41,7 +41,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.1.1"
+    compile "com.twilio:video-android:1.2.0"
     compile 'com.koushikdutta.ion:ion:2.1.7'
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'


### PR DESCRIPTION
Features

- The SDK now uses TLS 1.2 in favor of TLS 1.0 to connect to Twilio’s servers.

Improvements

- Deprecated `LocalParticipant#release`. This method is not meant to be called and is now a 
no-op until it is removed in `2.0.0-preview1` release. [#132](https://github.com/twilio/video-quickstart-android/issues/132)
- Added more checks and logging to `CameraCapturer` to help identify cases when the camera service cannot be reached. [#126](https://github.com/twilio/video-quickstart-android/issues/126)
- Changed `getSupportedFormats` for `CameraCapturer`, `ScreenCapturer`, and `Camera2Capturer` to 
be `synchronized`.

Bug Fixes

- Fixed timing issue where camera was not always available after a video track was released. [#126](https://github.com/twilio/video-quickstart-android/issues/126)
