### PR TITLE
1.2.2 release

### DIFF
--- a/exampleAdvancedCameraCapturer/build.gradle
+++ b/exampleAdvancedCameraCapturer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.2.1"
+    compile "com.twilio:video-android:1.2.2"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleCustomVideoCapturer/build.gradle
+++ b/exampleCustomVideoCapturer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.2.1"
+    compile "com.twilio:video-android:1.2.2"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleCustomVideoRenderer/build.gradle
+++ b/exampleCustomVideoRenderer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.2.1"
+    compile "com.twilio:video-android:1.2.2"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleScreenCapturer/build.gradle
+++ b/exampleScreenCapturer/build.gradle
@@ -26,7 +26,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.2.1"
+    compile "com.twilio:video-android:1.2.2"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleVideoInvite/build.gradle
+++ b/exampleVideoInvite/build.gradle
@@ -34,7 +34,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 
-    compile "com.twilio:video-android:1.2.1"
+    compile "com.twilio:video-android:1.2.2"
     compile "com.google.firebase:firebase-messaging:10.0.1"
     compile 'com.squareup.retrofit2:retrofit:2.0.0-beta4'
     compile 'com.squareup.okhttp3:logging-interceptor:3.6.0'

--- a/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
+++ b/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
@@ -622,7 +622,6 @@ public class VideoInviteActivity extends AppCompatActivity {
         if (participant.getVideoTracks().size() > 0) {
             removeParticipantVideo(participant.getVideoTracks().get(0));
         }
-        participant.setListener(null);
         moveLocalVideoToPrimaryView();
     }
 

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -41,7 +41,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.2.1"
+    compile "com.twilio:video-android:1.2.2"
     compile 'com.koushikdutta.ion:ion:2.1.7'
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -387,7 +387,6 @@ public class VideoActivity extends AppCompatActivity {
         if (participant.getVideoTracks().size() > 0) {
             removeParticipantVideo(participant.getVideoTracks().get(0));
         }
-        participant.setListener(null);
         moveLocalVideoToPrimaryView();
     }
 


### PR DESCRIPTION
Improvements

- Calling `Participant#setListener` with `null` is no longer allowed. 

Bug Fixes

- Removed reference to `LocalMedia` in `CameraCapturer` javadoc.
- Fixed race condition that could result in track events not being raised.