### PR TITLE
2.0.0-preview1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 [ ![Download](https://api.bintray.com/packages/twilio/releases/video-android/images/download.svg) ](https://bintray.com/twilio/releases/video-android/_latestVersion)
-[![Javadoc](https://img.shields.io/badge/javadoc-OK-blue.svg)](https://media.twiliocdn.com/sdk/android/video/latest/docs/)
+[![Javadoc](https://img.shields.io/badge/javadoc-OK-blue.svg)](https://media.twiliocdn.com/sdk/android/video/releases/2.0.0-preview1/docs/)
+
+> NOTE: These sample applications use the Twilio Video 2.0.0 APIs. We will continue to 
+update them throughout the preview and beta period. For examples using our GA 1.x APIs, please see 
+the [master](https://github.com/twilio/video-quickstart-android) branch.
 
 # Twilio Video Quickstart for Android
 

--- a/exampleAdvancedCameraCapturer/build.gradle
+++ b/exampleAdvancedCameraCapturer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.3.0"
+    compile "com.twilio:video-android:2.0.0-preview1"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleCustomVideoCapturer/build.gradle
+++ b/exampleCustomVideoCapturer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.3.0"
+    compile "com.twilio:video-android:2.0.0-preview1"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleCustomVideoRenderer/build.gradle
+++ b/exampleCustomVideoRenderer/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.3.0"
+    compile "com.twilio:video-android:2.0.0-preview1"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleScreenCapturer/build.gradle
+++ b/exampleScreenCapturer/build.gradle
@@ -26,7 +26,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.3.0"
+    compile "com.twilio:video-android:2.0.0-preview1"
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/exampleVideoInvite/build.gradle
+++ b/exampleVideoInvite/build.gradle
@@ -34,7 +34,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 
-    compile "com.twilio:video-android:1.3.0"
+    compile "com.twilio:video-android:2.0.0-preview1"
     compile "com.google.firebase:firebase-messaging:10.0.1"
     compile 'com.squareup.retrofit2:retrofit:2.0.0-beta4'
     compile 'com.squareup.okhttp3:logging-interceptor:3.6.0'

--- a/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
+++ b/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
@@ -147,7 +147,7 @@ public class VideoInviteActivity extends AppCompatActivity {
     private FloatingActionButton muteActionFab;
     private android.support.v7.app.AlertDialog alertDialog;
     private AudioManager audioManager;
-    private String remoteParticipantIdentify;
+    private String remoteParticipantIdentity;
 
     private int previousAudioMode;
     private VideoRenderer localVideoView;
@@ -579,8 +579,8 @@ public class VideoInviteActivity extends AppCompatActivity {
                     .show();
             return;
         }
-        remoteParticipantIdentify = remoteParticipant.getIdentity();
-        statusTextView.setText("RemoteParticipant " + remoteParticipantIdentify + " joined");
+        remoteParticipantIdentity = remoteParticipant.getIdentity();
+        statusTextView.setText("RemoteParticipant " + remoteParticipantIdentity + " joined");
 
         /*
          * Add remote participant renderer
@@ -628,7 +628,7 @@ public class VideoInviteActivity extends AppCompatActivity {
      */
     private void removeParticipant(RemoteParticipant remoteParticipant) {
         statusTextView.setText("Participant "+remoteParticipant.getIdentity()+ " left.");
-        if (!remoteParticipant.getIdentity().equals(remoteParticipantIdentify)) {
+        if (!remoteParticipant.getIdentity().equals(remoteParticipantIdentity)) {
             return;
         }
 

--- a/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
+++ b/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
@@ -29,14 +29,17 @@ import android.widget.Toast;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.twilio.video.AudioTrack;
 import com.twilio.video.CameraCapturer;
 import com.twilio.video.CameraCapturer.CameraSource;
 import com.twilio.video.ConnectOptions;
 import com.twilio.video.LocalAudioTrack;
 import com.twilio.video.LocalParticipant;
 import com.twilio.video.LocalVideoTrack;
-import com.twilio.video.Participant;
+import com.twilio.video.RemoteAudioTrack;
+import com.twilio.video.RemoteAudioTrackPublication;
+import com.twilio.video.RemoteParticipant;
+import com.twilio.video.RemoteVideoTrack;
+import com.twilio.video.RemoteVideoTrackPublication;
 import com.twilio.video.Room;
 import com.twilio.video.RoomState;
 import com.twilio.video.TwilioException;
@@ -144,7 +147,7 @@ public class VideoInviteActivity extends AppCompatActivity {
     private FloatingActionButton muteActionFab;
     private android.support.v7.app.AlertDialog alertDialog;
     private AudioManager audioManager;
-    private String participantIdentity;
+    private String remoteParticipantIdentify;
 
     private int previousAudioMode;
     private VideoRenderer localVideoView;
@@ -334,11 +337,16 @@ public class VideoInviteActivity extends AppCompatActivity {
         super.onResume();
         registerReceiver();
         /*
-         * If the local video track was removed when the app was put in the background, add it back.
+         * If the local video track was unpublished when the app was put in the background,
+         * re-create and publish again.
          */
         if (checkPermissionForCameraAndMicrophone() && localVideoTrack == null && cameraCapturer != null) {
             localVideoTrack = LocalVideoTrack.create(this, true, cameraCapturer);
             localVideoTrack.addRenderer(localVideoView);
+
+            if (localParticipant != null) {
+                localParticipant.publishTrack(localVideoTrack);
+            }
         }
     }
 
@@ -346,20 +354,20 @@ public class VideoInviteActivity extends AppCompatActivity {
     protected void onPause() {
         unregisterReceiver();
         /*
-         * Remove the local video track before going in the background. This ensures that the
+         * Release the local video track before going in the background. This ensures that the
          * camera can be used by other applications while this app is in the background.
          *
          * If this local video track is being shared in a Room, participants will be notified
-         * that the track has been removed.
+         * that the track has been unpublished.
          */
         if (localVideoTrack != null) {
             /*
-             * If this local video track is being shared in a Room, remove from local
-             * participant before releasing the video track. Participants will be notified that
-             * the track has been removed.
+             * If this local video track is being shared in a Room, unpublish from room before
+             * releasing the video track. Participants will be notified that the track has been
+             * removed.
              */
             if (localParticipant != null) {
-                localParticipant.removeVideoTrack(localVideoTrack);
+                localParticipant.unpublishTrack(localVideoTrack);
             }
             localVideoTrack.release();
             localVideoTrack = null;
@@ -558,9 +566,9 @@ public class VideoInviteActivity extends AppCompatActivity {
     }
 
     /*
-     * Called when participant joins the room
+     * Called when remote participant joins the room
      */
-    private void addParticipant(Participant participant) {
+    private void addRemoteParticipant(RemoteParticipant remoteParticipant) {
         /*
          * This app only displays video for one additional participant per Room
          */
@@ -571,26 +579,34 @@ public class VideoInviteActivity extends AppCompatActivity {
                     .show();
             return;
         }
-        participantIdentity = participant.getIdentity();
-        statusTextView.setText("Participant "+ participantIdentity + " joined");
+        remoteParticipantIdentify = remoteParticipant.getIdentity();
+        statusTextView.setText("RemoteParticipant " + remoteParticipantIdentify + " joined");
 
         /*
-         * Add participant renderer
+         * Add remote participant renderer
          */
-        if (participant.getVideoTracks().size() > 0) {
-            addParticipantVideo(participant.getVideoTracks().get(0));
+        if (remoteParticipant.getRemoteVideoTracks().size() > 0) {
+            RemoteVideoTrackPublication remoteVideoTrackPublication =
+                    remoteParticipant.getRemoteVideoTracks().get(0);
+
+            /*
+             * Only render video tracks that are subscribed to
+             */
+            if (remoteVideoTrackPublication.isTrackSubscribed()) {
+                addRemoteParticipantVideo(remoteVideoTrackPublication.getRemoteVideoTrack());
+            }
         }
 
         /*
          * Start listening for participant media events
          */
-        participant.setListener(mediaListener());
+        remoteParticipant.setListener(mediaListener());
     }
 
     /*
      * Set primary view as renderer for participant video track
      */
-    private void addParticipantVideo(VideoTrack videoTrack) {
+    private void addRemoteParticipantVideo(VideoTrack videoTrack) {
         moveLocalVideoToThumbnailView();
         primaryVideoView.setMirror(false);
         videoTrack.addRenderer(primaryVideoView);
@@ -610,17 +626,25 @@ public class VideoInviteActivity extends AppCompatActivity {
     /*
      * Called when participant leaves the room
      */
-    private void removeParticipant(Participant participant) {
-        statusTextView.setText("Participant "+participant.getIdentity()+ " left.");
-        if (!participant.getIdentity().equals(participantIdentity)) {
+    private void removeParticipant(RemoteParticipant remoteParticipant) {
+        statusTextView.setText("Participant "+remoteParticipant.getIdentity()+ " left.");
+        if (!remoteParticipant.getIdentity().equals(remoteParticipantIdentify)) {
             return;
         }
 
         /*
          * Remove participant renderer
          */
-        if (participant.getVideoTracks().size() > 0) {
-            removeParticipantVideo(participant.getVideoTracks().get(0));
+        if (remoteParticipant.getRemoteVideoTracks().size() > 0) {
+            RemoteVideoTrackPublication remoteVideoTrackPublication =
+                    remoteParticipant.getRemoteVideoTracks().get(0);
+
+            /*
+             * Remove video only if subscribed to participant track.
+             */
+            if (remoteVideoTrackPublication.isTrackSubscribed()) {
+                removeParticipantVideo(remoteVideoTrackPublication.getRemoteVideoTrack());
+            }
         }
         moveLocalVideoToPrimaryView();
     }
@@ -651,8 +675,8 @@ public class VideoInviteActivity extends AppCompatActivity {
                 statusTextView.setText("Connected to " + room.getName());
                 setTitle(room.getName());
 
-                for (Participant participant :  room.getParticipants()) {
-                    addParticipant(participant);
+                for (RemoteParticipant remoteParticipant :  room.getRemoteParticipants()) {
+                    addRemoteParticipant(remoteParticipant);
                     break;
                 }
             }
@@ -677,14 +701,14 @@ public class VideoInviteActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onParticipantConnected(Room room, Participant participant) {
-                addParticipant(participant);
+            public void onParticipantConnected(Room room, RemoteParticipant remoteParticipant) {
+                addRemoteParticipant(remoteParticipant);
 
             }
 
             @Override
-            public void onParticipantDisconnected(Room room, Participant participant) {
-                removeParticipant(participant);
+            public void onParticipantDisconnected(Room room, RemoteParticipant remoteParticipant) {
+                removeParticipant(remoteParticipant);
             }
 
             @Override
@@ -705,48 +729,83 @@ public class VideoInviteActivity extends AppCompatActivity {
         };
     }
 
-    private Participant.Listener mediaListener() {
-        return new Participant.Listener() {
-
+    private RemoteParticipant.Listener mediaListener() {
+        return new RemoteParticipant.Listener() {
             @Override
-            public void onAudioTrackAdded(Participant participant, AudioTrack audioTrack) {
-                statusTextView.setText("onAudioTrackAdded");
+            public void onAudioTrackPublished(RemoteParticipant remoteParticipant,
+                                              RemoteAudioTrackPublication remoteAudioTrackPublication) {
+                statusTextView.setText("onAudioTrackPublished");
             }
 
             @Override
-            public void onAudioTrackRemoved(Participant participant, AudioTrack audioTrack) {
-                statusTextView.setText("onAudioTrackRemoved");
+            public void onAudioTrackUnpublished(RemoteParticipant remoteParticipant,
+                                                RemoteAudioTrackPublication remoteAudioTrackPublication) {
+                statusTextView.setText("onAudioTrackPublished");
             }
 
             @Override
-            public void onVideoTrackAdded(Participant participant, VideoTrack videoTrack) {
-                statusTextView.setText("onVideoTrackAdded");
-                addParticipantVideo(videoTrack);
+            public void onVideoTrackPublished(RemoteParticipant remoteParticipant,
+                                              RemoteVideoTrackPublication remoteVideoTrackPublication) {
+                statusTextView.setText("onVideoTrackPublished");
             }
 
             @Override
-            public void onVideoTrackRemoved(Participant participant, VideoTrack videoTrack) {
-                statusTextView.setText("onVideoTrackRemoved");
-                removeParticipantVideo(videoTrack);
+            public void onVideoTrackUnpublished(RemoteParticipant remoteParticipant,
+                                                RemoteVideoTrackPublication remoteVideoTrackPublication) {
+                statusTextView.setText("onVideoTrackUnpublished");
             }
 
             @Override
-            public void onAudioTrackEnabled(Participant participant, AudioTrack audioTrack) {
+            public void onAudioTrackSubscribed(RemoteParticipant remoteParticipant,
+                                               RemoteAudioTrackPublication remoteAudioTrackPublication,
+                                               RemoteAudioTrack remoteAudioTrack) {
+                statusTextView.setText("onAudioTrackSubscribed");
+            }
+
+            @Override
+            public void onAudioTrackUnsubscribed(RemoteParticipant remoteParticipant,
+                                                 RemoteAudioTrackPublication remoteAudioTrackPublication,
+                                                 RemoteAudioTrack remoteAudioTrack) {
+                statusTextView.setText("onAudioTrackUnsubscribed");
+            }
+
+            @Override
+            public void onVideoTrackSubscribed(RemoteParticipant remoteParticipant,
+                                               RemoteVideoTrackPublication remoteVideoTrackPublication,
+                                               RemoteVideoTrack remoteVideoTrack) {
+                statusTextView.setText("onVideoTrackSubscribed");
+                addRemoteParticipantVideo(remoteVideoTrack);
+            }
+
+            @Override
+            public void onVideoTrackUnsubscribed(RemoteParticipant remoteParticipant,
+                                                 RemoteVideoTrackPublication remoteVideoTrackPublication,
+                                                 RemoteVideoTrack remoteVideoTrack) {
+                statusTextView.setText("onVideoTrackUnsubscribed");
+                removeParticipantVideo(remoteVideoTrack);
+            }
+
+            @Override
+            public void onAudioTrackEnabled(RemoteParticipant remoteParticipant,
+                                            RemoteAudioTrackPublication remoteAudioTrackPublication) {
 
             }
 
             @Override
-            public void onAudioTrackDisabled(Participant participant, AudioTrack audioTrack) {
+            public void onAudioTrackDisabled(RemoteParticipant remoteParticipant,
+                                             RemoteAudioTrackPublication remoteAudioTrackPublication) {
 
             }
 
             @Override
-            public void onVideoTrackEnabled(Participant participant, VideoTrack videoTrack) {
+            public void onVideoTrackEnabled(RemoteParticipant remoteParticipant,
+                                            RemoteVideoTrackPublication remoteVideoTrackPublication) {
 
             }
 
             @Override
-            public void onVideoTrackDisabled(Participant participant, VideoTrack videoTrack) {
+            public void onVideoTrackDisabled(RemoteParticipant remoteParticipant,
+                                             RemoteVideoTrackPublication remoteVideoTrackPublication) {
 
             }
         };

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -41,7 +41,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
 
-    compile "com.twilio:video-android:1.3.0"
+    compile "com.twilio:video-android:2.0.0-preview1"
     compile 'com.koushikdutta.ion:ion:2.1.7'
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:design:24.2.1'


### PR DESCRIPTION
Features

- Added `EncodingParameters` which constrains how much bandwidth is used to share audio and 
video. This object has been added to `ConnectOptions` and can also be set on `LocalParticipant` 
after joining a `Room`.
- Added two static `create` methods to `LocalAudioTrack` and `LocalVideoTrack` that allow creating
named tracks. The following snippet demonstrates how to create a video track named "screen".

      LocalVideoTrack screenVideoTrack = LocalVideoTrack.create(context, 
              true, 
              screenCapturer, 
              "screen"); 
              
- Moved `getTrackId` from `Track` to `LocalAudioTrack` and `LocalVideoTrack`.
- Added `AudioCodec` and `VideoCodec` as part of the new codec preferences API. Audio and video
codec preferences can be set in `ConnectOptions`. The following snippet
demonstrates how to prefer the iSAC audio codec and VP9 video codec.

      ConnectOptions aliceConnectOptions = new ConnectOptions.Builder(aliceToken)
              .roomName(roomName)
              .preferAudioCodecs(Collections.singletonList(VideoCodec.ISAC))
              .preferVideoCodecs(Collections.singletonList(VideoCodec.VP9))
              .build();

- Added `RemoteAudioTrack` and `RemoteVideoTrack`. These new objects extend `AudioTrack` and 
`VideoTrack` respectively and come with the following new method: 
  - `getName` - Returns the name of the track or an empty string if no name is specified.
- Added `enablePlayback` to new `RemoteAudioTrack` which allows developers to mute the audio 
 received from a `RemoteParticipant`.
- Added `RemoteAudioTrackPublication` which represents a published `RemoteAudioTrack`. This new 
class contains the following methods: 
  - `getTrackSid` - Returns the identifier of a remote video track within the scope of a `Room`.
  - `getTrackName` - Returns the name of the track or an empty string if no name was specified.
  - `isTrackEnabled` - Checks if the track is enabled.
  - `getAudioTrack` - Returns the base class object of the remote audio track published.
  - `getRemoteAudioTrack` - Returns the remote audio track published.
- Added `RemoteVideoTrackPublication` which represents a published `RemoteVideoTrack`. This new 
class contains the following methods: 
  - `getTrackSid` - Returns the identifier of a remote video track within the scope of a `Room`.
  - `getTrackName` - Returns the name of the track or an empty string if no name was specified.
  - `isTrackEnabled` - Checks if the track is enabled.
  - `getAudioTrack` - Returns the base class object of the remote audio track published.
  - `getRemoteAudioTrack` - Returns the remote audio track published.
- Added `LocalAudioTrackPublication` which represents a published `LocalAudioTrack`. This new 
class contains the following methods: 
  - `getTrackSid` - Returns the identifier of a local video track within the scope of a `Room`.
  - `getTrackName` - Returns the name of the track or an empty string if no name was specified.
  - `isTrackEnabled` - Checks if the track is enabled.
  - `getAudioTrack` - Returns the base class object of the local audio track published.
  - `getLocalAudioTrack` - Returns the local audio track published.
- Added `LocalVideoTrackPublication` which represents a published `LocalVideoTrack`. This new 
class contains the following methods: 
  - `getTrackSid` - Returns the identifier of a local video track within the scope of a `Room`.
  - `getTrackName` - Returns the name of the track or an empty string if no name was specified.
  - `isTrackEnabled` - Checks if the track is enabled.
  - `getAudioTrack` - Returns the base class object of the local audio track published.
  - `getLocalAudioTrack` - Returns the local audio track published.
- Converted `Participant` to an interface and migrated previous functionality into 
`RemoteParticipant`. `LocalParticipant` and the new `RemoteParticipant` implement `Participant`.
- Added `RemoteParticipant#getRemoteAudioTracks` and `RemoteParticipant#getRemoteVideoTracks` which
return `List<RemoteAudioTrackPublication>` and `List<RemoteVideoTrackPublication>` respectively.
- Moved `Participant.Listener` to `RemoteParticipant.Listener` and changed the listener to return
`RemoteParticipant`, `RemoteAudioTrackPublication`, and `RemoteVideoTrackPublication` in callbacks.
- Renamed the following `RemoteParticipant.Listener` callbacks:
  - `onAudioTrackAdded` renamed to `onAudioTrackPublished`.
  - `onAudioTrackRemoved` renamed to `onAudioTrackUnpublished`.
  - `onVideoTrackAdded` renamed to `onVideoTrackPublished`.
  - `onVideoTrackRemoved` renamed to `onVideoTrackUnpublished`.
- Added the following callbacks to `RemoteParticipant.Listener`:
  - `onAudioTrackSubscribed` - Indicates when audio is flowing from a remote particpant's audio 
  track. This callback includes the `RemoteAudioTrack` that was subscribed to.
  - `onAudioTrackUnsubscribed` - Indicates when audio is no longer flowing from a remote 
  partipant's audio track. This callback includes the `RemoteAudioTrack` that was subscribed to.
  - `onVideoTrackSubscribed` - Indicates when video is flowing from a remote participant's video 
  track. This callback includes the `RemoteVideoTrack` that was subscribed to.
  - `onVideoTrackUnsubscribed` - Inidicates when video is no longer flowing from a remote
  participant's video track. This callback includes the `RemoteVideoTrack` that was subscribed to.
- Renamed `TrackStats` to `RemoteTrackStats`, `AudioTrackStats` to `RemoteAudioTrackStats`, and
`VideoTrackStats` to `RemoteVideoTrackStats`
- Renamed `LocalParticipant#addAudioTrack` and `LocalParticipant#addVideoTrack` to 
`LocalParticipant#publishedTrack`.
- Added `LocalParticipant.Listener` which is provides the following callbacks:
  - `onAudioTrackPublished` - Indicates when a local audio track has been published to a `Room`.
  - `onVideoTrackPublished` - Indicates when a local video track has been published to a `Room`.
- Added `LocalParticipant#getLocalAudioTracks` and `LocalParticipant#getLocalVideoTracks` which
return `List<LocalAudioTrackPublication>` and `List<LocalVideoTrackPublication>` respectively.

Improvements

- Null renderers cannot be added or removed from local or remote video tracks.
- Renderers cannot be added or removed from a `LocalVideoTrack` that has been released. 

Bug Fixes

- Change visibility of `LocalParticipant#release()` from public to package. 
[#132](https://github.com/twilio/video-quickstart-android/issues/132)