### PR TITLE
Codec Preferences

### DIFF
--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -44,5 +44,6 @@ dependencies {
     compile "com.twilio:video-android:2.0.0-preview1"
     compile 'com.koushikdutta.ion:ion:2.1.7'
     compile 'com.android.support:appcompat-v7:24.2.1'
+    compile 'com.android.support:preference-v14:24.2.1'
     compile 'com.android.support:design:24.2.1'
 }

--- a/quickstart/src/main/AndroidManifest.xml
+++ b/quickstart/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
         </activity>
         <activity
             android:name=".activity.SettingsActivity"
+            android:theme="@style/AppTheme.Settings"
             android:label="@string/title_activity_settings"
             android:parentActivityName=".activity.VideoActivity">
             <meta-data

--- a/quickstart/src/main/AndroidManifest.xml
+++ b/quickstart/src/main/AndroidManifest.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.twilio.video.quickstart">
+    package="com.twilio.video.quickstart">
 
-    <uses-feature android:name="android.hardware.camera"/>
-    <uses-feature android:name="android.hardware.camera.autofocus"/>
+    <uses-feature android:name="android.hardware.camera" />
+    <uses-feature android:name="android.hardware.camera.autofocus" />
     <uses-feature
         android:glEsVersion="0x00020000"
-        android:required="true"/>
+        android:required="true" />
 
-    <uses-permission android:name="android.permission.CAMERA"/>
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
-    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
     <application
         android:allowBackup="true"
@@ -23,11 +23,20 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".activity.VideoActivity"
-            android:configChanges="orientation|screenSize" >
+            android:configChanges="orientation|screenSize">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+        <activity
+            android:name=".activity.SettingsActivity"
+            android:label="@string/title_activity_settings"
+            android:parentActivityName=".activity.VideoActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.twilio.video.quickstart.activity.VideoActivity" />
         </activity>
     </application>
 

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/SettingsActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/SettingsActivity.java
@@ -39,14 +39,6 @@ public class SettingsActivity extends AppCompatActivity {
                 .commit();
     }
 
-    private void setupActionBar() {
-        ActionBar actionBar = getSupportActionBar();
-        if (actionBar != null) {
-            // Show the Up button in the action bar.
-            actionBar.setDisplayHomeAsUpEnabled(true);
-        }
-    }
-
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
@@ -55,6 +47,14 @@ public class SettingsActivity extends AppCompatActivity {
                 return true;
             default:
                 return super.onOptionsItemSelected(item);
+        }
+    }
+
+    private void setupActionBar() {
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            // Show the Up button in the action bar.
+            actionBar.setDisplayHomeAsUpEnabled(true);
         }
     }
 

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/SettingsActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/SettingsActivity.java
@@ -1,0 +1,131 @@
+package com.twilio.video.quickstart.activity;
+
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.preference.ListPreference;
+import android.support.v7.preference.Preference;
+import android.support.v7.preference.PreferenceFragmentCompat;
+import android.view.MenuItem;
+
+import com.twilio.video.AudioCodec;
+import com.twilio.video.VideoCodec;
+import com.twilio.video.quickstart.R;
+
+import org.webrtc.MediaCodecVideoDecoder;
+import org.webrtc.MediaCodecVideoEncoder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SettingsActivity extends AppCompatActivity {
+    public static final String PREF_AUDIO_CODEC = "audio_codec";
+    public static final String PREF_AUDIO_CODEC_DEFAULT = "OPUS";
+    public static final String PREF_VIDEO_CODEC = "video_codec";
+    public static final String PREF_VIDEO_CODEC_DEFAULT = "VP8";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setupActionBar();
+        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+        SettingsFragment settingsFragment = SettingsFragment.newInstance(sharedPreferences);
+        getSupportFragmentManager()
+                .beginTransaction()
+                .replace(android.R.id.content, settingsFragment)
+                .commit();
+    }
+
+    private void setupActionBar() {
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            // Show the Up button in the action bar.
+            actionBar.setDisplayHomeAsUpEnabled(true);
+        }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                finish();
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+    }
+
+    public static class SettingsFragment extends PreferenceFragmentCompat {
+        private SharedPreferences sharedPreferences;
+
+        public static SettingsFragment newInstance(SharedPreferences sharedPreferences) {
+            SettingsFragment settingsFragment = new SettingsFragment();
+            settingsFragment.sharedPreferences = sharedPreferences;
+
+            return settingsFragment;
+        }
+
+        @Override
+        public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+            addPreferencesFromResource(R.xml.settings);
+            setHasOptionsMenu(true);
+            setupCodecListPreference(AudioCodec.class,
+                    PREF_AUDIO_CODEC,
+                    PREF_AUDIO_CODEC_DEFAULT,
+                    (ListPreference) findPreference(PREF_AUDIO_CODEC));
+            setupCodecListPreference(VideoCodec.class,
+                    PREF_VIDEO_CODEC,
+                    PREF_VIDEO_CODEC_DEFAULT,
+                    (ListPreference) findPreference(PREF_VIDEO_CODEC));
+        }
+
+        @Override
+        public boolean onOptionsItemSelected(MenuItem item) {
+            int id = item.getItemId();
+            if (id == android.R.id.home) {
+                startActivity(new Intent(getActivity(), SettingsActivity.class));
+                return true;
+            }
+            return super.onOptionsItemSelected(item);
+        }
+
+        private <T extends Enum<T>> void setupCodecListPreference(Class<T> enumClass,
+                                                                  String key,
+                                                                  String defaultValue,
+                                                                  ListPreference preference) {
+            final List<String> codecEntries = new ArrayList<>();
+            final T[] codecs = enumClass.getEnumConstants();
+
+            // Create codec entries
+            for (T codec : codecs) {
+                codecEntries.add(codec.toString());
+            }
+
+            // Remove H264 if not supported
+            if (!MediaCodecVideoDecoder.isH264HwSupported() ||
+                    !MediaCodecVideoEncoder.isH264HwSupported()) {
+                codecEntries.remove(VideoCodec.H264.name());
+            }
+
+            // Bind value
+            final String value = sharedPreferences.getString(key, defaultValue);
+            final String[] codecStrings = new String[codecEntries.size()];
+            codecEntries.toArray(codecStrings);
+
+            preference.setEntries(codecStrings);
+            preference.setEntryValues(codecStrings);
+            preference.setValue(value);
+            preference.setSummary(value);
+            preference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+                @Override
+                public boolean onPreferenceChange(Preference preference, Object newValue) {
+                    preference.setSummary(newValue.toString());
+                    return true;
+                }
+            });
+        }
+    }
+}

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -3,6 +3,7 @@ package com.twilio.video.quickstart.activity;
 import android.Manifest;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.media.AudioManager;
 import android.os.Bundle;
@@ -11,8 +12,12 @@ import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.TextView;
@@ -21,6 +26,7 @@ import android.widget.Toast;
 import com.google.gson.JsonObject;
 import com.koushikdutta.async.future.FutureCallback;
 import com.koushikdutta.ion.Ion;
+import com.twilio.video.AudioCodec;
 import com.twilio.video.LocalParticipant;
 import com.twilio.video.RemoteAudioTrack;
 import com.twilio.video.RemoteAudioTrackPublication;
@@ -84,7 +90,7 @@ public class VideoActivity extends AppCompatActivity {
     private FloatingActionButton switchCameraActionFab;
     private FloatingActionButton localVideoActionFab;
     private FloatingActionButton muteActionFab;
-    private android.support.v7.app.AlertDialog alertDialog;
+    private AlertDialog connectDialog;
     private AudioManager audioManager;
     private String remoteParticipantIdentity;
 
@@ -115,7 +121,7 @@ public class VideoActivity extends AppCompatActivity {
         /*
          * Needed for setting/abandoning audio focus during call
          */
-        audioManager = (AudioManager)getSystemService(Context.AUDIO_SERVICE);
+        audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
 
         /*
          * Check camera and microphone permissions. Needed in Android M.
@@ -131,6 +137,24 @@ public class VideoActivity extends AppCompatActivity {
          * Set the initial state of the UI
          */
         intializeUI();
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.menu_video_activity, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case R.id.menu_settings:
+                startActivity(new Intent(this, SettingsActivity.class));
+                return true;
+            default:
+                return false;
+        }
     }
 
     @Override
@@ -320,9 +344,11 @@ public class VideoActivity extends AppCompatActivity {
      */
     private void showConnectDialog() {
         EditText roomEditText = new EditText(this);
-        alertDialog = Dialog.createConnectDialog(roomEditText,
-                connectClickListener(roomEditText), cancelConnectDialogClickListener(), this);
-        alertDialog.show();
+        connectDialog = Dialog.createConnectDialog(roomEditText,
+                connectClickListener(roomEditText),
+                cancelConnectDialogClickListener(),
+                this);
+        connectDialog.show();
     }
 
     /*
@@ -616,7 +642,7 @@ public class VideoActivity extends AppCompatActivity {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 intializeUI();
-                alertDialog.dismiss();
+                connectDialog.dismiss();
             }
         };
     }

--- a/quickstart/src/main/java/com/twilio/video/quickstart/dialog/Dialog.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/dialog/Dialog.java
@@ -9,7 +9,10 @@ import com.twilio.video.quickstart.R;
 
 public class Dialog {
 
-    public static AlertDialog createConnectDialog(EditText participantEditText, DialogInterface.OnClickListener callParticipantsClickListener, DialogInterface.OnClickListener cancelClickListener, Context context) {
+    public static AlertDialog createConnectDialog(EditText participantEditText,
+                                                  DialogInterface.OnClickListener callParticipantsClickListener,
+                                                  DialogInterface.OnClickListener cancelClickListener,
+                                                  Context context) {
         AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(context);
 
         alertDialogBuilder.setIcon(R.drawable.ic_call_black_24dp);
@@ -23,11 +26,17 @@ public class Dialog {
         return alertDialogBuilder.create();
     }
 
-    private static void setRoomNameFieldInDialog(EditText roomNameEditText, AlertDialog.Builder alertDialogBuilder, Context context) {
+    private static void setRoomNameFieldInDialog(EditText roomNameEditText,
+                                                 AlertDialog.Builder alertDialogBuilder,
+                                                 Context context) {
         roomNameEditText.setHint("room name");
         int horizontalPadding = context.getResources().getDimensionPixelOffset(R.dimen.activity_horizontal_margin);
         int verticalPadding = context.getResources().getDimensionPixelOffset(R.dimen.activity_vertical_margin);
-        alertDialogBuilder.setView(roomNameEditText, horizontalPadding, verticalPadding, horizontalPadding, 0);
+        alertDialogBuilder.setView(roomNameEditText,
+                horizontalPadding,
+                verticalPadding,
+                horizontalPadding,
+                0);
     }
 
 }

--- a/quickstart/src/main/res/menu/menu_video_activity.xml
+++ b/quickstart/src/main/res/menu/menu_video_activity.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/menu_settings"
+        android:enabled="true"
+        android:title="@string/settings"
+        android:visible="true"
+        app:showAsAction="never" />
+</menu>

--- a/quickstart/src/main/res/values/strings.xml
+++ b/quickstart/src/main/res/values/strings.xml
@@ -5,4 +5,11 @@
     <string name="error_retrieving_access_token">Error retrieving token</string>
     <string name="log_out">Log Out</string>
     <string name="permissions_needed">Camera and Microphone permissions needed. Please allow in App Settings for additional functionality.</string>
+    <string name="settings">Settings</string>
+    <string name="title_activity_settings">Settings</string>
+
+    <!-- Strings related to Settings -->
+
+    <string name="pref_title_audio_codec">Audio Codec</string>
+    <string name="pref_title_video_codec">Video Codec</string>
 </resources>

--- a/quickstart/src/main/res/values/strings.xml
+++ b/quickstart/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
 
     <!-- Strings related to Settings -->
 
+    <string name="codec_title">Set your preferred audio and video codec. Not all codecs are supported with Group rooms. The media server will fallback to OPUS or VP8 if a preferred codec is not supported.</string>
     <string name="pref_title_audio_codec">Audio Codec</string>
     <string name="pref_title_video_codec">Video Codec</string>
 </resources>

--- a/quickstart/src/main/res/values/styles.xml
+++ b/quickstart/src/main/res/values/styles.xml
@@ -6,6 +6,7 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+        <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
     </style>
 
     <style name="AppTheme.NoActionBar">

--- a/quickstart/src/main/res/values/styles.xml
+++ b/quickstart/src/main/res/values/styles.xml
@@ -6,7 +6,6 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
-        <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
     </style>
 
     <style name="AppTheme.NoActionBar">
@@ -17,5 +16,11 @@
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
+
+    <style name="AppTheme.Settings" parent="AppTheme">
+        <item name="colorAccent">@color/colorPrimary</item>
+        <item name="displayOptions">showHome|showTitle|homeAsUp</item>
+        <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
+    </style>
 
 </resources>

--- a/quickstart/src/main/res/xml/settings.xml
+++ b/quickstart/src/main/res/xml/settings.xml
@@ -1,0 +1,15 @@
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <ListPreference
+        android:key="audio_codec"
+        android:negativeButtonText="@null"
+        android:positiveButtonText="@null"
+        android:title="@string/pref_title_audio_codec" />
+
+    <ListPreference
+        android:key="video_codec"
+        android:negativeButtonText="@null"
+        android:positiveButtonText="@null"
+        android:title="@string/pref_title_video_codec" />
+
+</PreferenceScreen>

--- a/quickstart/src/main/res/xml/settings.xml
+++ b/quickstart/src/main/res/xml/settings.xml
@@ -1,15 +1,15 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <ListPreference
-        android:key="audio_codec"
-        android:negativeButtonText="@null"
-        android:positiveButtonText="@null"
-        android:title="@string/pref_title_audio_codec" />
-
-    <ListPreference
-        android:key="video_codec"
-        android:negativeButtonText="@null"
-        android:positiveButtonText="@null"
-        android:title="@string/pref_title_video_codec" />
-
+    <PreferenceCategory
+        android:title="@string/codec_title">
+        <ListPreference
+            android:key="audio_codec"
+            android:negativeButtonText="@null"
+            android:positiveButtonText="@null"
+            android:title="@string/pref_title_audio_codec" />
+        <ListPreference
+            android:key="video_codec"
+            android:negativeButtonText="@null"
+            android:positiveButtonText="@null"
+            android:title="@string/pref_title_video_codec" />
+    </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
This PR adds a settings screen that allows user to change the preferred audio and video codec. If the device does not support H264, the preference will be removed from the settings as an option. Validated H264 usage with Galaxy S5 and Nexus 6. Validated Isac with Galaxy S5 and Asus Zenfone II.

Screenshots

![device-2017-09-12-170531](https://user-images.githubusercontent.com/1734140/30350814-e9d3d252-97dd-11e7-960e-4617ab26b6e0.png)
![device-2017-09-12-170515](https://user-images.githubusercontent.com/1734140/30350813-e9d34b5c-97dd-11e7-9705-b85c80c93f5a.png)
![device-2017-09-12-170501](https://user-images.githubusercontent.com/1734140/30350815-e9d6f7ca-97dd-11e7-87ca-64ec526f626b.png)
![device-2017-09-12-170446](https://user-images.githubusercontent.com/1734140/30350812-e9d1ffae-97dd-11e7-9bb8-9ffd4acf6bc7.png)
