### PR TITLE
Sender Bandwidth Constraints

### DIFF
--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/SettingsActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/SettingsActivity.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.preference.EditTextPreference;
 import android.support.v7.preference.ListPreference;
 import android.support.v7.preference.Preference;
 import android.support.v7.preference.PreferenceFragmentCompat;
@@ -26,6 +27,10 @@ public class SettingsActivity extends AppCompatActivity {
     public static final String PREF_AUDIO_CODEC_DEFAULT = "OPUS";
     public static final String PREF_VIDEO_CODEC = "video_codec";
     public static final String PREF_VIDEO_CODEC_DEFAULT = "VP8";
+    public static final String PREF_SENDER_MAX_AUDIO_BITRATE = "sender_max_audio_bitrate";
+    public static final String PREF_SENDER_MAX_AUDIO_BITRATE_DEFAULT = "0";
+    public static final String PREF_SENDER_MAX_VIDEO_BITRATE = "sender_max_video_bitrate";
+    public static final String PREF_SENDER_MAX_VIDEO_BITRATE_DEFAULT = "0";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -80,7 +85,15 @@ public class SettingsActivity extends AppCompatActivity {
                     PREF_VIDEO_CODEC,
                     PREF_VIDEO_CODEC_DEFAULT,
                     (ListPreference) findPreference(PREF_VIDEO_CODEC));
+            setupSenderBandwidthPreferences(PREF_SENDER_MAX_AUDIO_BITRATE,
+                    PREF_SENDER_MAX_AUDIO_BITRATE_DEFAULT,
+                    (EditTextPreference) findPreference(PREF_SENDER_MAX_AUDIO_BITRATE));
+            setupSenderBandwidthPreferences(PREF_SENDER_MAX_VIDEO_BITRATE,
+                    PREF_SENDER_MAX_VIDEO_BITRATE_DEFAULT,
+                    (EditTextPreference) findPreference(PREF_SENDER_MAX_VIDEO_BITRATE));
         }
+
+
 
         @Override
         public boolean onOptionsItemSelected(MenuItem item) {
@@ -120,6 +133,23 @@ public class SettingsActivity extends AppCompatActivity {
             preference.setValue(value);
             preference.setSummary(value);
             preference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+                @Override
+                public boolean onPreferenceChange(Preference preference, Object newValue) {
+                    preference.setSummary(newValue.toString());
+                    return true;
+                }
+            });
+        }
+
+        private void setupSenderBandwidthPreferences(String key,
+                                                     String defaultValue,
+                                                     EditTextPreference editTextPreference) {
+            String value = sharedPreferences.getString(key, defaultValue);
+
+            // Set layout with input type number for edit text
+            editTextPreference.setDialogLayoutResource(R.layout.preference_dialog_number_edittext);
+            editTextPreference.setSummary(value);
+            editTextPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
                 @Override
                 public boolean onPreferenceChange(Preference preference, Object newValue) {
                     preference.setSummary(newValue.toString());

--- a/quickstart/src/main/res/layout/preference_dialog_number_edittext.xml
+++ b/quickstart/src/main/res/layout/preference_dialog_number_edittext.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_marginTop="48dp"
+    android:layout_marginBottom="48dp"
+    android:overScrollMode="ifContentScrolls">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="5dip"
+        android:orientation="vertical">
+
+        <TextView android:id="@android:id/message"
+            style="?android:attr/textAppearanceSmall"
+            android:layout_marginBottom="48dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="?android:attr/textColorSecondary" />
+
+        <EditText
+            android:id="@android:id/edit"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="number"/>
+
+    </LinearLayout>
+
+</ScrollView>

--- a/quickstart/src/main/res/values/strings.xml
+++ b/quickstart/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="codec_title">Set your preferred audio and video codec. Not all codecs are supported with Group rooms. The media server will fallback to OPUS or VP8 if a preferred codec is not supported.</string>
     <string name="pref_title_audio_codec">Audio Codec</string>
     <string name="pref_title_video_codec">Video Codec</string>
-    <string name="sender_bandwidth_constraints">Set sender bandwidth constraints.</string>
+    <string name="sender_bandwidth_constraints">Set sender bandwidth constraints. Zero represents the WebRTC default value which varies by codec.</string>
     <string name="max_audio_bitrate">Max Audio Bitrate (bits per second)</string>
     <string name="max_video_bitrate">Max Video Bitrate (bits per second)</string>
 </resources>

--- a/quickstart/src/main/res/values/strings.xml
+++ b/quickstart/src/main/res/values/strings.xml
@@ -13,4 +13,7 @@
     <string name="codec_title">Set your preferred audio and video codec. Not all codecs are supported with Group rooms. The media server will fallback to OPUS or VP8 if a preferred codec is not supported.</string>
     <string name="pref_title_audio_codec">Audio Codec</string>
     <string name="pref_title_video_codec">Video Codec</string>
+    <string name="sender_bandwidth_constraints">Set sender bandwidth constraints.</string>
+    <string name="max_audio_bitrate">Max Audio Bitrate (bits per second)</string>
+    <string name="max_video_bitrate">Max Video Bitrate (bits per second)</string>
 </resources>

--- a/quickstart/src/main/res/xml/settings.xml
+++ b/quickstart/src/main/res/xml/settings.xml
@@ -1,15 +1,27 @@
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <PreferenceCategory
+<android.support.v7.preference.PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <android.support.v7.preference.PreferenceCategory
         android:title="@string/codec_title">
-        <ListPreference
+        <android.support.v7.preference.ListPreference
             android:key="audio_codec"
             android:negativeButtonText="@null"
             android:positiveButtonText="@null"
             android:title="@string/pref_title_audio_codec" />
-        <ListPreference
+        <android.support.v7.preference.ListPreference
             android:key="video_codec"
             android:negativeButtonText="@null"
             android:positiveButtonText="@null"
             android:title="@string/pref_title_video_codec" />
-    </PreferenceCategory>
-</PreferenceScreen>
+    </android.support.v7.preference.PreferenceCategory>
+    <android.support.v7.preference.PreferenceCategory
+        android:title="@string/sender_bandwidth_constraints">
+        <android.support.v7.preference.EditTextPreference
+            android:key="sender_max_audio_bitrate"
+            android:title="@string/max_audio_bitrate"
+            android:defaultValue="0"/>
+        <android.support.v7.preference.EditTextPreference
+            android:key="sender_max_video_bitrate"
+            android:title="@string/max_video_bitrate"
+            android:defaultValue="0" />
+    </android.support.v7.preference.PreferenceCategory>
+</android.support.v7.preference.PreferenceScreen>


### PR DESCRIPTION
Add sender bandwidth constraints. Validated various bitrates on Nexus 6, Galaxy S5, and Nexus 9 as well as updating the EncodingParameters via `LocalParticipant.setEncodingParameters`.

Screenshots
![device-2017-09-13-155825](https://user-images.githubusercontent.com/1734140/30400505-b0f30d8a-989c-11e7-89f4-ba839fd5093a.png)
![device-2017-09-13-155813](https://user-images.githubusercontent.com/1734140/30400503-b0efd886-989c-11e7-89af-de200cd5c8af.png)
![device-2017-09-13-160149](https://user-images.githubusercontent.com/1734140/30400563-e526463a-989c-11e7-8d4a-eba31def8574.png)

