### PR TITLE
Update to Video Android 1.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '1.3.0'
+            'videoAndroid': '1.3.1'
     ]
     repositories {
         jcenter()


### PR DESCRIPTION
####1.3.1

Improvements

- Fixed case on some devices where `CameraCapturer` incorrectly reported a failure to close the 
camera.
- Improved echo cancellation on Nexus 6P and Nexus 6 by enabling hardware echo canceller and disabling OpenSL ES.