### PR TITLE
2.0.0 preview3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,18 @@ To get started with the Quickstart application follow these steps:
 
 1. Open this project in Android Studio and select the quickstart app module.
   <img width="700px" src="images/quickstart/android_studio_quickstart.png"/>
-2. Type in an identity and click on "Generate Access Token" from the [testing tools page](https://www.twilio.com/user/account/video/dev-tools/testing-tools).
+
+2. Type in an identity and click on "Generate Access Token" from the [Testing Tools page](https://www.twilio.com/console/video/runtime/testing-tools).
   <img width="700px" src="images/quickstart/generate_access_token.png"/>
+
 3. Paste the Access Token into the VideoActivity.java.
   <img width="700px" src="images/quickstart/activity_access_token.png"/>
+
 4. Run the quickstart app on an Android device or Android emulator.
+
 5. Press the call button at the bottom right portion of the screen and type a room name to connect to a Room.
   <img height="500px" src="images/quickstart/connect_dialog.png"/>
+
 6. On another device, use an additional access token with a different identity to connect to the same room. 
 
 ## Examples
@@ -121,8 +126,7 @@ experience when sharing audio to a `Room`.
         if (enable) {
             previousAudioMode = audioManager.getMode();
             // Request audio focus before making any device switch.
-            audioManager.requestAudioFocus(null, AudioManager.STREAM_VOICE_CALL,
-                    AudioManager.AUDIOFOCUS_GAIN_TRANSIENT);
+            requestAudioFocus();
             /*
              * Use MODE_IN_COMMUNICATION as the default audio mode. It is required
              * to be in this mode when playout and/or recording starts for the best
@@ -139,6 +143,29 @@ experience when sharing audio to a `Room`.
             audioManager.setMode(previousAudioMode);
             audioManager.abandonAudioFocus(null);
             audioManager.setMicrophoneMute(previousMicrophoneMute);
+        }
+    }
+
+    private void requestAudioFocus() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            AudioAttributes playbackAttributes = new AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                    .build();
+            AudioFocusRequest focusRequest =
+                    new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
+                            .setAudioAttributes(playbackAttributes)
+                            .setAcceptsDelayedFocusGain(true)
+                            .setOnAudioFocusChangeListener(
+                                    new AudioManager.OnAudioFocusChangeListener() {
+                                        @Override
+                                        public void onAudioFocusChange(int i) { }
+                                    })
+                            .build();
+            audioManager.requestAudioFocus(focusRequest);
+        } else {
+            audioManager.requestAudioFocus(null, AudioManager.STREAM_VOICE_CALL,
+                    AudioManager.AUDIOFOCUS_GAIN_TRANSIENT);
         }
     }
 
@@ -178,9 +205,9 @@ You'll need to gather a couple of configuration options from your Twilio develop
  
 Credential | Description
 ---------- | -----------
-Twilio Account SID | Your main Twilio account identifier - [find it on your dashboard](https://www.twilio.com/user/account/video).
-API Key | Used to authenticate - [generate one here](https://www.twilio.com/user/account/messaging/dev-tools/api-keys).
-API Secret | Used to authenticate - [just like the above, you'll get one here](https://www.twilio.com/user/account/messaging/dev-tools/api-keys).
+Twilio Account SID | Your main Twilio account identifier - [find it on your dashboard](https://www.twilio.com/console).
+API Key | Used to authenticate - [generate one here](https://www.twilio.com/console/video/runtime/api-keys).
+API Secret | Used to authenticate - [just like the above, you'll get one here](https://www.twilio.com/console/video/runtime/api-keys).
 
 #### A Note on API Keys
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,11 @@
 
 buildscript {
     ext.versions = [
-            'compileSdk': 25,
-            'buildTools': '25.0.2',
+            'compileSdk': 26,
+            'buildTools': '26.0.1',
             'minSdk': 16,
-            'targetSdk': 25,
-            'supportLibrary': '25.1.0',
+            'targetSdk': 26,
+            'supportLibrary': '26.1.0',
             'firebase': '10.0.1',
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '2.0.0-preview2'
+            'videoAndroid': '2.0.0-preview3'
     ]
     repositories {
         jcenter()

--- a/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
+++ b/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
@@ -353,7 +353,7 @@ public class VideoInviteActivity extends AppCompatActivity {
              * If connected to a Room then share the local video track.
              */
             if (localParticipant != null) {
-                localParticipant.addVideoTrack(localVideoTrack);
+                localParticipant.publishTrack(localVideoTrack);
             }
         }
     }

--- a/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
+++ b/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
@@ -8,7 +8,10 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
+import android.media.AudioAttributes;
+import android.media.AudioFocusRequest;
 import android.media.AudioManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
@@ -337,15 +340,20 @@ public class VideoInviteActivity extends AppCompatActivity {
         super.onResume();
         registerReceiver();
         /*
-         * If the local video track was unpublished when the app was put in the background,
-         * re-create and publish again.
+         * If the local video track was released when the app was put in the background, recreate.
          */
-        if (checkPermissionForCameraAndMicrophone() && localVideoTrack == null && cameraCapturer != null) {
+        if (localVideoTrack == null &&
+                checkPermissionForCameraAndMicrophone() &&
+                cameraCapturer != null) {
             localVideoTrack = LocalVideoTrack.create(this, true, cameraCapturer);
             localVideoTrack.addRenderer(localVideoView);
 
+
+            /*
+             * If connected to a Room then share the local video track.
+             */
             if (localParticipant != null) {
-                localParticipant.publishTrack(localVideoTrack);
+                localParticipant.addVideoTrack(localVideoTrack);
             }
         }
     }
@@ -452,11 +460,17 @@ public class VideoInviteActivity extends AppCompatActivity {
         localAudioTrack = LocalAudioTrack.create(this, true);
 
         // Share your camera
-        cameraCapturer = new CameraCapturer(this, CameraSource.FRONT_CAMERA);
+        cameraCapturer = new CameraCapturer(this, getAvailableCameraSource());
         localVideoTrack = LocalVideoTrack.create(this, true, cameraCapturer);
         primaryVideoView.setMirror(true);
         localVideoTrack.addRenderer(primaryVideoView);
         localVideoView = primaryVideoView;
+    }
+
+    private CameraSource getAvailableCameraSource() {
+        return (CameraCapturer.isSourceAvailable(CameraSource.FRONT_CAMERA)) ?
+                (CameraSource.FRONT_CAMERA) :
+                (CameraSource.BACK_CAMERA);
     }
 
     private void connectToRoom(String roomName) {
@@ -615,8 +629,10 @@ public class VideoInviteActivity extends AppCompatActivity {
     private void moveLocalVideoToThumbnailView() {
         if (thumbnailVideoView.getVisibility() == View.GONE) {
             thumbnailVideoView.setVisibility(View.VISIBLE);
-            localVideoTrack.removeRenderer(primaryVideoView);
-            localVideoTrack.addRenderer(thumbnailVideoView);
+            if (localVideoTrack != null) {
+                localVideoTrack.removeRenderer(primaryVideoView);
+                localVideoTrack.addRenderer(thumbnailVideoView);
+            }
             localVideoView = thumbnailVideoView;
             thumbnailVideoView.setMirror(cameraCapturer.getCameraSource() ==
                     CameraSource.FRONT_CAMERA);
@@ -943,8 +959,7 @@ public class VideoInviteActivity extends AppCompatActivity {
         if (focus) {
             previousAudioMode = audioManager.getMode();
             // Request audio focus before making any device switch.
-            audioManager.requestAudioFocus(null, AudioManager.STREAM_VOICE_CALL,
-                    AudioManager.AUDIOFOCUS_GAIN_TRANSIENT);
+            requestAudioFocus();
             /*
              * Use MODE_IN_COMMUNICATION as the default audio mode. It is required
              * to be in this mode when playout and/or recording starts for the best
@@ -955,6 +970,29 @@ public class VideoInviteActivity extends AppCompatActivity {
         } else {
             audioManager.setMode(previousAudioMode);
             audioManager.abandonAudioFocus(null);
+        }
+    }
+
+    private void requestAudioFocus() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            AudioAttributes playbackAttributes = new AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                    .build();
+            AudioFocusRequest focusRequest =
+                    new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
+                            .setAudioAttributes(playbackAttributes)
+                            .setAcceptsDelayedFocusGain(true)
+                            .setOnAudioFocusChangeListener(
+                                    new AudioManager.OnAudioFocusChangeListener() {
+                                        @Override
+                                        public void onAudioFocusChange(int i) { }
+                                    })
+                            .build();
+            audioManager.requestAudioFocus(focusRequest);
+        } else {
+            audioManager.requestAudioFocus(null, AudioManager.STREAM_VOICE_CALL,
+                    AudioManager.AUDIOFOCUS_GAIN_TRANSIENT);
         }
     }
 


### PR DESCRIPTION
Improvements

- Upgraded to Android Oreo from Nougat

Bug Fixes

- Fixed case on some devices where `CameraCapturer` incorrectly reported a failure to close the 
camera.
- Improved echo cancellation on Nexus 6P and Nexus 6 by enabling hardware echo canceller and disabling OpenSL ES.
- Fixed crash disconnecting from `Room` that has not connected [#116](https://github.com/twilio/video-quickstart-android/issues/116)