### PR TITLE
Update to 1.3.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '1.3.7'
+            'videoAndroid': '1.3.8'
     ]
     ext.getSecretProperty = { key, defaultValue ->
         def value = System.getenv(key);


### PR DESCRIPTION
Improvements

- Updated javadoc to include note about `VideoView#setVideoScaleType`. Scale type will only
 be applied to dimensions defined as `WRAP_CONTENT` or a custom value. Setting a width or height to 
 `MATCH_PARENT` results in the video being scaled to fill the maximum value of the dimension.
- Add warning log when calling `setVideoScaleType` when width or height is set to `MATCH_PARENT`