### PR TITLE
2.0.0 preview6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '2.0.0-preview5'
+            'videoAndroid': '2.0.0-preview6'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->


### PR DESCRIPTION
Improvements

- `LocalDataTrack` name is no longer provided via static `create` method argument. DataTrack names
 are now provided via `DataTrackOptions`. Reference snippets below:
 
    Creating a `LocalDataTrack` with name _before_ `2.0.0-preview6`

        String dataTrackName = "data";
        LocalDataTrack localDataTrack = LocalDataTrack.create(context, dataTrackName);
     
    Creating a `LocalDataTrack` with name _after_ `2.0.0-preview6`

        String dataTrackName = "data";
        DataTrackOptions dataTrackOptions = new DataTrackOptions.Builder()
             .name("data")
             .build();
        LocalDataTrack localDataTrack = LocalDataTrack.create(context, dataTrackOptions);
        
- Updated javadoc to include note about `VideoView#setVideoScaleType`. Scale type will only
 be applied to dimensions defined as `WRAP_CONTENT` or a custom value. Setting a width or height to 
 `MATCH_PARENT` results in the video being scaled to fill the maximum value of the dimension.
- Add warning log when calling `setVideoScaleType` when width or height is set to `MATCH_PARENT`

Bug Fixes

- Fixed a potential crash when publishing or unpublishing a Data Track.