### PR TITLE
Update examples for 2.0.0-preview8 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '2.0.0-preview7'
+            'videoAndroid': '2.0.0-preview8'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->

--- a/exampleDataTrack/src/main/java/com/twilio/video/examples/datatrack/DataTrackActivity.java
+++ b/exampleDataTrack/src/main/java/com/twilio/video/examples/datatrack/DataTrackActivity.java
@@ -408,6 +408,12 @@ public class DataTrackActivity extends AppCompatActivity {
             }
 
             @Override
+            public void onAudioTrackSubscriptionFailed(RemoteParticipant remoteParticipant,
+                                                       RemoteAudioTrackPublication remoteAudioTrackPublication,
+                                                       TwilioException twilioException) {
+            }
+
+            @Override
             public void onDataTrackSubscribed(final RemoteParticipant remoteParticipant,
                                               RemoteDataTrackPublication remoteDataTrackPublication,
                                               final RemoteDataTrack remoteDataTrack) {
@@ -430,6 +436,12 @@ public class DataTrackActivity extends AppCompatActivity {
             }
 
             @Override
+            public void onDataTrackSubscriptionFailed(RemoteParticipant remoteParticipant,
+                                                      RemoteDataTrackPublication remoteDataTrackPublication,
+                                                      TwilioException twilioException) {
+            }
+
+            @Override
             public void onVideoTrackSubscribed(RemoteParticipant remoteParticipant,
                                                RemoteVideoTrackPublication remoteVideoTrackPublication,
                                                RemoteVideoTrack remoteVideoTrack) {
@@ -439,6 +451,12 @@ public class DataTrackActivity extends AppCompatActivity {
             public void onVideoTrackUnsubscribed(RemoteParticipant remoteParticipant,
                                                  RemoteVideoTrackPublication remoteVideoTrackPublication,
                                                  RemoteVideoTrack remoteVideoTrack) {
+            }
+
+            @Override
+            public void onVideoTrackSubscriptionFailed(RemoteParticipant remoteParticipant,
+                                                       RemoteVideoTrackPublication remoteVideoTrackPublication,
+                                                       TwilioException twilioException) {
             }
 
             @Override

--- a/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
+++ b/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
@@ -801,6 +801,13 @@ public class VideoInviteActivity extends AppCompatActivity {
             }
 
             @Override
+            public void onAudioTrackSubscriptionFailed(RemoteParticipant remoteParticipant,
+                                                       RemoteAudioTrackPublication remoteAudioTrackPublication,
+                                                       TwilioException twilioException) {
+                statusTextView.setText("onAudioTrackSubscriptionFailed");
+            }
+
+            @Override
             public void onVideoTrackSubscribed(RemoteParticipant remoteParticipant,
                                                RemoteVideoTrackPublication remoteVideoTrackPublication,
                                                RemoteVideoTrack remoteVideoTrack) {
@@ -817,6 +824,18 @@ public class VideoInviteActivity extends AppCompatActivity {
             }
 
             @Override
+            public void onVideoTrackSubscriptionFailed(RemoteParticipant remoteParticipant,
+                                                       RemoteVideoTrackPublication remoteVideoTrackPublication,
+                                                       TwilioException twilioException) {
+                statusTextView.setText("onVideoTrackSubscriptionFailed");
+                Snackbar.make(connectActionFab,
+                        String.format("Failed to subscribe to %s video track",
+                                remoteParticipant.getIdentity()),
+                        Snackbar.LENGTH_LONG)
+                        .show();
+            }
+
+            @Override
             public void onDataTrackSubscribed(RemoteParticipant remoteParticipant,
                                               RemoteDataTrackPublication remoteDataTrackPublication,
                                               RemoteDataTrack remoteDataTrack) {
@@ -828,6 +847,13 @@ public class VideoInviteActivity extends AppCompatActivity {
                                                 RemoteDataTrackPublication remoteDataTrackPublication,
                                                 RemoteDataTrack remoteDataTrack) {
                 statusTextView.setText("onDataTrackUnsubscribed");
+            }
+
+            @Override
+            public void onDataTrackSubscriptionFailed(RemoteParticipant remoteParticipant,
+                                                      RemoteDataTrackPublication remoteDataTrackPublication,
+                                                      TwilioException twilioException) {
+                statusTextView.setText("onDataTrackSubscriptionFailed");
             }
 
             @Override

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -787,9 +787,25 @@ public class VideoActivity extends AppCompatActivity {
             }
 
             @Override
+            public void onAudioTrackSubscriptionFailed(RemoteParticipant remoteParticipant,
+                                                       RemoteAudioTrackPublication remoteAudioTrackPublication,
+                                                       TwilioException twilioException) {
+                Log.i(TAG, String.format("onAudioTrackSubscriptionFailed: " +
+                                "[RemoteParticipant: identity=%s], " +
+                                "[RemoteAudioTrackPublication: sid=%b, name=%s]" +
+                                "[TwilioException: code=%d, message=%s]",
+                        remoteParticipant.getIdentity(),
+                        remoteAudioTrackPublication.getTrackSid(),
+                        remoteAudioTrackPublication.getTrackName(),
+                        twilioException.getCode(),
+                        twilioException.getMessage()));
+                videoStatusTextView.setText("onAudioTrackSubscriptionFailed");
+            }
+
+            @Override
             public void onDataTrackSubscribed(RemoteParticipant remoteParticipant,
-                                               RemoteDataTrackPublication remoteDataTrackPublication,
-                                               RemoteDataTrack remoteDataTrack) {
+                                              RemoteDataTrackPublication remoteDataTrackPublication,
+                                              RemoteDataTrack remoteDataTrack) {
                 Log.i(TAG, String.format("onDataTrackSubscribed: " +
                                 "[RemoteParticipant: identity=%s], " +
                                 "[RemoteDataTrack: enabled=%b, name=%s]",
@@ -801,8 +817,8 @@ public class VideoActivity extends AppCompatActivity {
 
             @Override
             public void onDataTrackUnsubscribed(RemoteParticipant remoteParticipant,
-                                                 RemoteDataTrackPublication remoteDataTrackPublication,
-                                                 RemoteDataTrack remoteDataTrack) {
+                                                RemoteDataTrackPublication remoteDataTrackPublication,
+                                                RemoteDataTrack remoteDataTrack) {
                 Log.i(TAG, String.format("onDataTrackUnsubscribed: " +
                                 "[RemoteParticipant: identity=%s], " +
                                 "[RemoteDataTrack: enabled=%b, name=%s]",
@@ -810,6 +826,22 @@ public class VideoActivity extends AppCompatActivity {
                         remoteDataTrack.isEnabled(),
                         remoteDataTrack.getName()));
                 videoStatusTextView.setText("onDataTrackUnsubscribed");
+            }
+
+            @Override
+            public void onDataTrackSubscriptionFailed(RemoteParticipant remoteParticipant,
+                                                      RemoteDataTrackPublication remoteDataTrackPublication,
+                                                      TwilioException twilioException) {
+                Log.i(TAG, String.format("onDataTrackSubscriptionFailed: " +
+                                "[RemoteParticipant: identity=%s], " +
+                                "[RemoteDataTrackPublication: sid=%b, name=%s]" +
+                                "[TwilioException: code=%d, message=%s]",
+                        remoteParticipant.getIdentity(),
+                        remoteDataTrackPublication.getTrackSid(),
+                        remoteDataTrackPublication.getTrackName(),
+                        twilioException.getCode(),
+                        twilioException.getMessage()));
+                videoStatusTextView.setText("onDataTrackSubscriptionFailed");
             }
 
             @Override
@@ -838,6 +870,27 @@ public class VideoActivity extends AppCompatActivity {
                         remoteVideoTrack.getName()));
                 videoStatusTextView.setText("onVideoTrackUnsubscribed");
                 removeParticipantVideo(remoteVideoTrack);
+            }
+
+            @Override
+            public void onVideoTrackSubscriptionFailed(RemoteParticipant remoteParticipant,
+                                                       RemoteVideoTrackPublication remoteVideoTrackPublication,
+                                                       TwilioException twilioException) {
+                Log.i(TAG, String.format("onVideoTrackSubscriptionFailed: " +
+                                "[RemoteParticipant: identity=%s], " +
+                                "[RemoteVideoTrackPublication: sid=%b, name=%s]" +
+                                "[TwilioException: code=%d, message=%s]",
+                        remoteParticipant.getIdentity(),
+                        remoteVideoTrackPublication.getTrackSid(),
+                        remoteVideoTrackPublication.getTrackName(),
+                        twilioException.getCode(),
+                        twilioException.getMessage()));
+                videoStatusTextView.setText("onVideoTrackSubscriptionFailed");
+                Snackbar.make(connectActionFab,
+                        String.format("Failed to subscribe to %s video track",
+                                remoteParticipant.getIdentity()),
+                        Snackbar.LENGTH_LONG)
+                        .show();
             }
 
             @Override

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
@@ -230,6 +230,18 @@ class VideoActivity : AppCompatActivity() {
             videoStatusTextView.text = "onAudioTrackUnsubscribed"
         }
 
+        override fun onAudioTrackSubscriptionFailed(remoteParticipant: RemoteParticipant,
+                                                    remoteAudioTrackPublication: RemoteAudioTrackPublication,
+                                                    twilioException: TwilioException) {
+            Log.i(TAG, "onAudioTrackSubscriptionFailed: " +
+                    "[RemoteParticipant: identity=${remoteParticipant.identity}], " +
+                    "[RemoteAudioTrackPublication: sid=${remoteAudioTrackPublication.trackSid}, " +
+                    "name=${remoteAudioTrackPublication.trackName}]" +
+                    "[TwilioException: code=${twilioException.code}, " +
+                    "message=${twilioException.message}]")
+            videoStatusTextView.text = "onAudioTrackSubscriptionFailed"
+        }
+
         override fun onDataTrackSubscribed(remoteParticipant: RemoteParticipant,
                                            remoteDataTrackPublication: RemoteDataTrackPublication,
                                            remoteDataTrack: RemoteDataTrack) {
@@ -248,6 +260,18 @@ class VideoActivity : AppCompatActivity() {
                     "[RemoteDataTrack: enabled=${remoteDataTrack.isEnabled}, " +
                     "name=${remoteDataTrack.name}]")
             videoStatusTextView.text = "onDataTrackUnsubscribed"
+        }
+
+        override fun onDataTrackSubscriptionFailed(remoteParticipant: RemoteParticipant,
+                                                    remoteDataTrackPublication: RemoteDataTrackPublication,
+                                                    twilioException: TwilioException) {
+            Log.i(TAG, "onDataTrackSubscriptionFailed: " +
+                    "[RemoteParticipant: identity=${remoteParticipant.identity}], " +
+                    "[RemoteDataTrackPublication: sid=${remoteDataTrackPublication.trackSid}, " +
+                    "name=${remoteDataTrackPublication.trackName}]" +
+                    "[TwilioException: code=${twilioException.code}, " +
+                    "message=${twilioException.message}]")
+            videoStatusTextView.text = "onDataTrackSubscriptionFailed"
         }
 
         override fun onVideoTrackSubscribed(remoteParticipant: RemoteParticipant,
@@ -270,6 +294,22 @@ class VideoActivity : AppCompatActivity() {
                     "name=${remoteVideoTrack.name}]")
             videoStatusTextView.text = "onVideoTrackUnsubscribed"
             removeParticipantVideo(remoteVideoTrack)
+        }
+
+        override fun onVideoTrackSubscriptionFailed(remoteParticipant: RemoteParticipant,
+                                                    remoteVideoTrackPublication: RemoteVideoTrackPublication,
+                                                    twilioException: TwilioException) {
+            Log.i(TAG, "onVideoTrackSubscriptionFailed: " +
+                    "[RemoteParticipant: identity=${remoteParticipant.identity}], " +
+                    "[RemoteVideoTrackPublication: sid=${remoteVideoTrackPublication.trackSid}, " +
+                    "name=${remoteVideoTrackPublication.trackName}]" +
+                    "[TwilioException: code=${twilioException.code}, " +
+                    "message=${twilioException.message}]")
+            videoStatusTextView.text = "onVideoTrackSubscriptionFailed"
+            Snackbar.make(connectActionFab,
+                    "Failed to subscribe to ${remoteParticipant.identity}",
+                    Snackbar.LENGTH_LONG)
+                    .show()
         }
 
         override fun onAudioTrackEnabled(remoteParticipant: RemoteParticipant,


### PR DESCRIPTION
Features

- Added the following callbacks to `RemoteParticipant.Listener`
  - `onAudioTrackSubscriptionFailed` - Notifies listener that an audio track could not be 
  subscribed to.
  - `onVideoTrackSubscriptionFailed` - Notifies listener that a video track could not be 
  subscribed to.
  - `onDataTrackSubscriptionFailed` - Notifies listener that a data track could not be 
  subscribed to.
- Added `trackSid` to `BaseTrackStats`.

Bug Fixes

- Removed public `getEncodingOptions` method from `ConnectOptions`.