### PR TITLE
Update to 1.3.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '1.3.11'
+            'videoAndroid': '1.3.12'
     ]
     ext.getSecretProperty = { key, defaultValue ->
         def value = System.getenv(key)


### PR DESCRIPTION
Bug Fixes

- ICE URIs using the `turns` scheme are now supported. The SDK will now use `turns` by default if turn is enabled for your Room.
- ICE URIs using the `stuns` scheme are now supported.
- Resolved a condition where ICE candidates might not be applied in Peer-to-Peer Rooms.