### PR TITLE
2.0.0 beta3 Release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '2.0.0-beta2'
+            'videoAndroid': '2.0.0-beta3'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->
@@ -38,7 +38,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
         classpath 'com.google.gms:google-services:3.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Oct 31 10:10:40 CDT 2017
+#Tue Mar 27 15:40:05 CDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
@@ -88,7 +88,7 @@ class VideoActivity : AppCompatActivity() {
     private val roomListener = object : Room.Listener {
         override fun onConnected(room: Room) {
             localParticipant = room.localParticipant
-            videoStatusTextView.text = "Connected to $room.name"
+            videoStatusTextView.text = "Connected to ${room.name}"
             title = room.name
 
             // Only one participant is supported
@@ -103,7 +103,7 @@ class VideoActivity : AppCompatActivity() {
 
         override fun onDisconnected(room: Room, e: TwilioException?) {
             localParticipant = null
-            videoStatusTextView.text = "Disconnected from $room.name"
+            videoStatusTextView.text = "Disconnected from ${room.name}"
             this@VideoActivity.room = null
             // Only reinitialize the UI if disconnect was not called from onDestroy()
             if (!disconnectedFromOnDestroy) {
@@ -704,7 +704,7 @@ class VideoActivity : AppCompatActivity() {
     }
 
     private fun connectClickListener(roomEditText: EditText): DialogInterface.OnClickListener {
-        return DialogInterface.OnClickListener { dialog, which ->
+        return DialogInterface.OnClickListener { _, _ ->
             /*
              * Connect to room
              */
@@ -727,7 +727,7 @@ class VideoActivity : AppCompatActivity() {
     }
 
     private fun cancelConnectDialogClickListener(): DialogInterface.OnClickListener {
-        return DialogInterface.OnClickListener { dialog, which ->
+        return DialogInterface.OnClickListener { _, _ ->
             initializeUI()
             alertDialog!!.dismiss()
         }


### PR DESCRIPTION
Improvements

- Improved internal logic for retrieving ice servers and resolving outbound DNS.

Bug Fixes

- ICE URIs using the turns and stuns scheme are now supported.
 The SDK will now use turns by default if turn is enabled for your Room.
- Resolved a condition where ICE candidates might not be applied in Peer-to-Peer Rooms.
- Quieted unnecessary warning logs when preferring codecs.
- Fixed a bug where onDisconnected was not getting invoked due to a race condition between a
 network handover and a user initiated disconnect call.