### PR TITLE
Update to 2.0.0-beta4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '2.0.0-beta3'
+            'videoAndroid': '2.0.0-beta4'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/SettingsActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/SettingsActivity.java
@@ -13,24 +13,41 @@ import android.support.v7.preference.PreferenceFragmentCompat;
 import android.view.MenuItem;
 
 import com.twilio.video.AudioCodec;
+import com.twilio.video.G722Codec;
+import com.twilio.video.H264Codec;
+import com.twilio.video.IsacCodec;
+import com.twilio.video.OpusCodec;
+import com.twilio.video.PcmaCodec;
+import com.twilio.video.PcmuCodec;
 import com.twilio.video.VideoCodec;
+import com.twilio.video.Vp8Codec;
+import com.twilio.video.Vp9Codec;
 import com.twilio.video.quickstart.R;
 
 import org.webrtc.MediaCodecVideoDecoder;
 import org.webrtc.MediaCodecVideoEncoder;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class SettingsActivity extends AppCompatActivity {
     public static final String PREF_AUDIO_CODEC = "audio_codec";
-    public static final String PREF_AUDIO_CODEC_DEFAULT = "OPUS";
+    public static final String PREF_AUDIO_CODEC_DEFAULT = OpusCodec.NAME;
     public static final String PREF_VIDEO_CODEC = "video_codec";
-    public static final String PREF_VIDEO_CODEC_DEFAULT = "VP8";
+    public static final String PREF_VIDEO_CODEC_DEFAULT = Vp8Codec.NAME;
     public static final String PREF_SENDER_MAX_AUDIO_BITRATE = "sender_max_audio_bitrate";
     public static final String PREF_SENDER_MAX_AUDIO_BITRATE_DEFAULT = "0";
     public static final String PREF_SENDER_MAX_VIDEO_BITRATE = "sender_max_video_bitrate";
     public static final String PREF_SENDER_MAX_VIDEO_BITRATE_DEFAULT = "0";
+
+    private static final String[] VIDEO_CODEC_NAMES = new String[] {
+            Vp8Codec.NAME, H264Codec.NAME, Vp9Codec.NAME
+    };
+
+    private static final String[] AUDIO_CODEC_NAMES = new String[] {
+            IsacCodec.NAME, OpusCodec.NAME, PcmaCodec.NAME, PcmuCodec.NAME, G722Codec.NAME
+    };
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -105,29 +122,25 @@ public class SettingsActivity extends AppCompatActivity {
             return super.onOptionsItemSelected(item);
         }
 
-        private <T extends Enum<T>> void setupCodecListPreference(Class<T> enumClass,
-                                                                  String key,
-                                                                  String defaultValue,
-                                                                  ListPreference preference) {
-            final List<String> codecEntries = new ArrayList<>();
-            final T[] codecs = enumClass.getEnumConstants();
-
-            // Create codec entries
-            for (T codec : codecs) {
-                codecEntries.add(codec.toString());
-            }
+        private void setupCodecListPreference(Class codecClass,
+                                              String key,
+                                              String defaultValue,
+                                              ListPreference preference) {
+            List<String> codecEntries = (codecClass == AudioCodec.class) ?
+                    Arrays.asList(AUDIO_CODEC_NAMES) :
+                    Arrays.asList(VIDEO_CODEC_NAMES);
 
             // Remove H264 if not supported
             if (!MediaCodecVideoDecoder.isH264HwSupported() ||
                     !MediaCodecVideoEncoder.isH264HwSupported()) {
-                codecEntries.remove(VideoCodec.H264.name());
+                codecEntries.remove(H264Codec.NAME);
             }
+            String[] codecStrings = (String[]) codecEntries.toArray();
 
-            // Bind value
+            // Saved value
             final String value = sharedPreferences.getString(key, defaultValue);
-            final String[] codecStrings = new String[codecEntries.size()];
-            codecEntries.toArray(codecStrings);
 
+            // Bind values
             preference.setEntries(codecStrings);
             preference.setEntryValues(codecStrings);
             preference.setValue(value);

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -34,7 +34,13 @@ import com.koushikdutta.ion.Ion;
 import com.twilio.video.AudioCodec;
 import com.twilio.video.EncodingParameters;
 import com.twilio.video.CameraCapturer;
+import com.twilio.video.G722Codec;
+import com.twilio.video.H264Codec;
+import com.twilio.video.IsacCodec;
 import com.twilio.video.LocalParticipant;
+import com.twilio.video.OpusCodec;
+import com.twilio.video.PcmaCodec;
+import com.twilio.video.PcmuCodec;
 import com.twilio.video.RemoteAudioTrack;
 import com.twilio.video.RemoteAudioTrackPublication;
 import com.twilio.video.RemoteDataTrack;
@@ -47,6 +53,8 @@ import com.twilio.video.Video;
 import com.twilio.video.VideoCodec;
 import com.twilio.video.VideoRenderer;
 import com.twilio.video.TwilioException;
+import com.twilio.video.Vp8Codec;
+import com.twilio.video.Vp9Codec;
 import com.twilio.video.quickstart.BuildConfig;
 import com.twilio.video.quickstart.R;
 import com.twilio.video.quickstart.dialog.Dialog;
@@ -246,12 +254,10 @@ public class VideoActivity extends AppCompatActivity {
         /*
          * Update preferred audio and video codec in case changed in settings
          */
-        audioCodec = getCodecPreference(SettingsActivity.PREF_AUDIO_CODEC,
-                SettingsActivity.PREF_AUDIO_CODEC_DEFAULT,
-                AudioCodec.class);
-        videoCodec = getCodecPreference(SettingsActivity.PREF_VIDEO_CODEC,
-                SettingsActivity.PREF_VIDEO_CODEC_DEFAULT,
-                VideoCodec.class);
+        audioCodec = getAudioCodecPreference(SettingsActivity.PREF_AUDIO_CODEC,
+                SettingsActivity.PREF_AUDIO_CODEC_DEFAULT);
+        videoCodec = getVideoCodecPreference(SettingsActivity.PREF_VIDEO_CODEC,
+                SettingsActivity.PREF_VIDEO_CODEC_DEFAULT);
 
         /*
          * Get latest encoding parameters
@@ -453,14 +459,43 @@ public class VideoActivity extends AppCompatActivity {
     }
 
     /*
-     * Get the preferred audio or video codec from shared preferences
+     * Get the preferred audio codec from shared preferences
      */
-    private <T extends Enum<T>> T getCodecPreference(String key,
-                                                     String defaultValue,
-                                                     final Class<T> enumClass) {
+    private AudioCodec getAudioCodecPreference(String key, String defaultValue) {
+        final String audioCodecName = preferences.getString(key, defaultValue);
 
-        final String codec = preferences.getString(key, defaultValue);
-        return Enum.valueOf(enumClass, codec);
+        switch (audioCodecName) {
+            case IsacCodec.NAME:
+                return new IsacCodec();
+            case OpusCodec.NAME:
+                return new OpusCodec();
+            case PcmaCodec.NAME:
+                return new PcmaCodec();
+            case PcmuCodec.NAME:
+                return new PcmuCodec();
+            case G722Codec.NAME:
+                return new G722Codec();
+            default:
+                return new OpusCodec();
+        }
+    }
+
+    /*
+     * Get the preferred video codec from shared preferences
+     */
+    private VideoCodec getVideoCodecPreference(String key, String defaultValue) {
+        final String videoCodecName = preferences.getString(key, defaultValue);
+
+        switch (videoCodecName) {
+            case Vp8Codec.NAME:
+                return new Vp8Codec();
+            case H264Codec.NAME:
+                return new H264Codec();
+            case Vp9Codec.NAME:
+                return new Vp9Codec();
+            default:
+                return new Vp8Codec();
+        }
     }
 
     private EncodingParameters getEncodingParameters() {

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/SettingsActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/SettingsActivity.kt
@@ -9,22 +9,26 @@ import android.support.v7.preference.ListPreference
 import android.support.v7.preference.Preference
 import android.support.v7.preference.PreferenceFragmentCompat
 import android.view.MenuItem
-import com.twilio.video.AudioCodec
-import com.twilio.video.VideoCodec
+import com.twilio.video.*
 import org.webrtc.MediaCodecVideoDecoder
 import org.webrtc.MediaCodecVideoEncoder
-import java.util.ArrayList
+import java.util.*
 
 class SettingsActivity : AppCompatActivity() {
     companion object {
-        val PREF_AUDIO_CODEC = "audio_codec"
-        val PREF_AUDIO_CODEC_DEFAULT = "OPUS"
-        val PREF_VIDEO_CODEC = "video_codec"
-        val PREF_VIDEO_CODEC_DEFAULT = "VP8"
-        val PREF_SENDER_MAX_AUDIO_BITRATE = "sender_max_audio_bitrate"
-        val PREF_SENDER_MAX_AUDIO_BITRATE_DEFAULT = "0"
-        val PREF_SENDER_MAX_VIDEO_BITRATE = "sender_max_video_bitrate"
-        val PREF_SENDER_MAX_VIDEO_BITRATE_DEFAULT = "0"
+        const val PREF_AUDIO_CODEC = "audio_codec"
+        const val PREF_AUDIO_CODEC_DEFAULT = OpusCodec.NAME
+        const val PREF_VIDEO_CODEC = "video_codec"
+        const val PREF_VIDEO_CODEC_DEFAULT = Vp8Codec.NAME
+        const val PREF_SENDER_MAX_AUDIO_BITRATE = "sender_max_audio_bitrate"
+        const val PREF_SENDER_MAX_AUDIO_BITRATE_DEFAULT = "0"
+        const val PREF_SENDER_MAX_VIDEO_BITRATE = "sender_max_video_bitrate"
+        const val PREF_SENDER_MAX_VIDEO_BITRATE_DEFAULT = "0"
+
+        val VIDEO_CODEC_NAMES = arrayOf(Vp8Codec.NAME, H264Codec.NAME, Vp9Codec.NAME)
+
+        val AUDIO_CODEC_NAMES = arrayOf(IsacCodec.NAME, OpusCodec.NAME, PcmaCodec.NAME,
+                PcmuCodec.NAME, G722Codec.NAME)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -82,17 +86,20 @@ class SettingsActivity : AppCompatActivity() {
             }
         }
 
-        private fun <T : Enum<T>> setupCodecListPreference(enumClass: Class<T>,
-                                                           key: String,
-                                                           defaultValue: String,
-                                                           listPreference: ListPreference) {
-            // Create codec entries
-            val codecEntries = enumClass.enumConstants.mapTo(ArrayList()) { it.toString() }
+        private fun setupCodecListPreference(codecClass: Class<*>,
+                                             key: String,
+                                             defaultValue: String,
+                                             listPreference: ListPreference) {
+            // Set codec entries
+            val codecEntries = if (codecClass == AudioCodec::class.java)
+                AUDIO_CODEC_NAMES.toMutableList()
+            else
+                VIDEO_CODEC_NAMES.toMutableList()
 
             // Remove H264 if not supported
             if (!MediaCodecVideoDecoder.isH264HwSupported() ||
                     !MediaCodecVideoEncoder.isH264HwSupported()) {
-                codecEntries.remove(VideoCodec.H264.name)
+                codecEntries.remove(H264Codec.NAME)
             }
 
             // Bind value

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
@@ -58,13 +58,29 @@ class VideoActivity : AppCompatActivity() {
      */
     private val audioCodec: AudioCodec
         get() {
-            return AudioCodec.valueOf(sharedPreferences.getString(SettingsActivity.PREF_AUDIO_CODEC,
-                    SettingsActivity.PREF_AUDIO_CODEC_DEFAULT))
+            val audioCodecName = sharedPreferences.getString(SettingsActivity.PREF_AUDIO_CODEC,
+                    SettingsActivity.PREF_AUDIO_CODEC_DEFAULT)
+
+            return when (audioCodecName) {
+                IsacCodec.NAME -> IsacCodec()
+                OpusCodec.NAME -> OpusCodec()
+                PcmaCodec.NAME -> PcmaCodec()
+                PcmuCodec.NAME -> PcmuCodec()
+                G722Codec.NAME -> G722Codec()
+                else -> OpusCodec()
+            }
         }
     private val videoCodec: VideoCodec
         get() {
-            return VideoCodec.valueOf(sharedPreferences.getString(SettingsActivity.PREF_VIDEO_CODEC,
-                    SettingsActivity.PREF_VIDEO_CODEC_DEFAULT))
+            val videoCodecName = sharedPreferences.getString(SettingsActivity.PREF_VIDEO_CODEC,
+                    SettingsActivity.PREF_VIDEO_CODEC_DEFAULT)
+
+            return when (videoCodecName) {
+                Vp8Codec.NAME -> Vp8Codec()
+                H264Codec.NAME -> H264Codec()
+                Vp9Codec.NAME -> Vp9Codec()
+                else -> Vp8Codec()
+            }
         }
 
     /*


### PR DESCRIPTION
Improvements

- Removed `trackId` from `BaseTrackStats`. `trackSid` or `trackName` can be used to identify
track stats in a `StatsReport`.
- Removed `getTrackId` from `LocalAudioTrack`, `LocalVideoTrack`, and `LocalDataTrack`.
- Added `getSid` to `RemoteAudioTrack`, `RemoteVideoTrack`, and `RemoteDataTrack`.
- Updated Android Gradle Plugin version to `3.1.0` and Gradle version to `4.4`.
- SDK now defers to WebRTC to validate ice servers and returns an error when a connection attempt
 fails due to invalid servers.
- Reduced the time needed to shutdown the signaling stack while disconnecting from a Room.
- Increased the signaling disconnect timeout interval to 1 second.
- Enable monotonic clock support in the signaling client.
- Initial connect message now includes client version metadata.
- Converted `AudioCodec` and `VideoCodec` from enums to abstract classes with concrete
implementations. The subclasses of `AudioCodec` and `VideoCodec` are the following:
  - `AudioCodec`
     - `IsacCodec`
     - `OpusCodec`
     - `PcmaCodec`
     - `PcmuCodec`
     - `G722Codec`
  - `VideoCodec`
     - `Vp8Codec`
     - `H264Codec`
     - `Vp9Codec`

 The following snippets demonstrate the before and after for setting codec preferences.

        // Setting preferences before 2.0.0-beta4
        ConnectOptions aliceConnectOptions = new ConnectOptions.Builder(aliceToken)
              .roomName(roomName)
              .preferAudioCodecs(Collections.singletonList(VideoCodec.ISAC))
              .preferVideoCodecs(Collections.singletonList(VideoCodec.VP9))
              .build();

        // Setting preferences with 2.0.0-beta4
        ConnectOptions aliceConnectOptions = new ConnectOptions.Builder(aliceToken)
              .roomName(roomName)
              .preferAudioCodecs(Collections.<AudioCodec>singletonList(new IsacCodec()))
              .preferVideoCodecs(Collections.<VideoCodec>singletonList(new Vp9Codec()))
              .build();


Bug Fixes

- Fixed a bug where the SDK hangs if DNS resolution fails and the user does not initiate disconnect.
- Resolved an issue with clock rollover in the Room signaling layer that resulted in high CPU usage
 and disconnects.
- The signaling client no longer logs access tokens.