### PR TITLE
2.1.0 Release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '2.0.1'
+            'videoAndroid': '2.1.0'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/SettingsActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/SettingsActivity.java
@@ -40,6 +40,8 @@ public class SettingsActivity extends AppCompatActivity {
     public static final String PREF_SENDER_MAX_AUDIO_BITRATE_DEFAULT = "0";
     public static final String PREF_SENDER_MAX_VIDEO_BITRATE = "sender_max_video_bitrate";
     public static final String PREF_SENDER_MAX_VIDEO_BITRATE_DEFAULT = "0";
+    public static final String PREF_VP8_SIMULCAST = "vp8_simulcast";
+    public static final boolean PREF_VP8_SIMULCAST_DEFAULT = false;
 
     private static final String[] VIDEO_CODEC_NAMES = new String[] {
             Vp8Codec.NAME, H264Codec.NAME, Vp9Codec.NAME

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -12,6 +12,7 @@ import android.media.AudioManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.provider.Settings;
 import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
@@ -488,7 +489,9 @@ public class VideoActivity extends AppCompatActivity {
 
         switch (videoCodecName) {
             case Vp8Codec.NAME:
-                return new Vp8Codec();
+                boolean simulcast = preferences.getBoolean(SettingsActivity.PREF_VP8_SIMULCAST,
+                        SettingsActivity.PREF_VP8_SIMULCAST_DEFAULT);
+                return new Vp8Codec(simulcast);
             case H264Codec.NAME:
                 return new H264Codec();
             case Vp9Codec.NAME:

--- a/quickstart/src/main/res/values/strings.xml
+++ b/quickstart/src/main/res/values/strings.xml
@@ -17,4 +17,5 @@
     <string name="max_audio_bitrate">Max Audio Bitrate (bits per second)</string>
     <string name="max_video_bitrate">Max Video Bitrate (bits per second)</string>
     <string name="turn_speaker_on">Speaker ON</string>
+    <string name="vp8_simulcast">VP8 Simulcast</string>
 </resources>

--- a/quickstart/src/main/res/xml/settings.xml
+++ b/quickstart/src/main/res/xml/settings.xml
@@ -12,6 +12,10 @@
             android:negativeButtonText="@null"
             android:positiveButtonText="@null"
             android:title="@string/pref_title_video_codec" />
+        <android.support.v7.preference.CheckBoxPreference
+            android:key="vp8_simulcast"
+            android:title="@string/vp8_simulcast"
+            android:defaultValue="false"/>
     </android.support.v7.preference.PreferenceCategory>
     <android.support.v7.preference.PreferenceCategory
         android:title="@string/sender_bandwidth_constraints">

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/SettingsActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/SettingsActivity.kt
@@ -24,6 +24,8 @@ class SettingsActivity : AppCompatActivity() {
         const val PREF_SENDER_MAX_AUDIO_BITRATE_DEFAULT = "0"
         const val PREF_SENDER_MAX_VIDEO_BITRATE = "sender_max_video_bitrate"
         const val PREF_SENDER_MAX_VIDEO_BITRATE_DEFAULT = "0"
+        const val PREF_VP8_SIMULCAST = "vp8_simulcast"
+        const val PREF_VP8_SIMULCAST_DEFAULT = false
 
         val VIDEO_CODEC_NAMES = arrayOf(Vp8Codec.NAME, H264Codec.NAME, Vp9Codec.NAME)
 

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
@@ -76,7 +76,12 @@ class VideoActivity : AppCompatActivity() {
                     SettingsActivity.PREF_VIDEO_CODEC_DEFAULT)
 
             return when (videoCodecName) {
-                Vp8Codec.NAME -> Vp8Codec()
+                Vp8Codec.NAME -> {
+                    val simulcast = sharedPreferences.getBoolean(
+                            SettingsActivity.PREF_VP8_SIMULCAST,
+                            SettingsActivity.PREF_VP8_SIMULCAST_DEFAULT)
+                    Vp8Codec(simulcast)
+                }
                 H264Codec.NAME -> H264Codec()
                 Vp9Codec.NAME -> Vp9Codec()
                 else -> Vp8Codec()

--- a/quickstartKotlin/src/main/res/values/strings.xml
+++ b/quickstartKotlin/src/main/res/values/strings.xml
@@ -12,4 +12,5 @@
     <string name="sender_bandwidth_constraints">Set sender bandwidth constraints. Zero represents the WebRTC default value which varies by codec.</string>
     <string name="max_audio_bitrate">Max Audio Bitrate (bits per second)</string>
     <string name="max_video_bitrate">Max Video Bitrate (bits per second)</string>
+    <string name="vp8_simulcast">VP8 Simulcast</string>
 </resources>

--- a/quickstartKotlin/src/main/res/xml/settings.xml
+++ b/quickstartKotlin/src/main/res/xml/settings.xml
@@ -12,6 +12,10 @@
             android:negativeButtonText="@null"
             android:positiveButtonText="@null"
             android:title="@string/pref_title_video_codec" />
+        <android.support.v7.preference.CheckBoxPreference
+            android:key="vp8_simulcast"
+            android:title="@string/vp8_simulcast"
+            android:defaultValue="false"/>
     </android.support.v7.preference.PreferenceCategory>
     <android.support.v7.preference.PreferenceCategory
         android:title="@string/sender_bandwidth_constraints">


### PR DESCRIPTION
Features

- Added `simulcast` property to `Vp8Codec`. Enabling simulcast causes the encoder to generate
multiple spatial and temporal layers for the video that is published. Simulcast should only be
enabled in a Group Room.

Bug Fixes

- Fixed a bug where the SDK could crash when unsubscribing from a data track and disconnecting from the room at the same time.
- Fixed a rare crash that occurs when disconnecting from a `Room`.
- Fixed an issue which could cause DTLS roles to be negotiated incorrectly in a multi-party Peer-to-Peer Room.

---

Added VP8 Simulcast checkbox preference (screenshot below)

![device-2018-05-29-185304](https://user-images.githubusercontent.com/1734140/40691517-d5a07e2e-6371-11e8-80e7-5f64691eb240.png)
