### PR TITLE
1.3.15  Release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.30'
+    ext.kotlin_version = '1.2.41'
     ext.versions = [
             'compileSdk': 27,
             'buildTools': '27.0.3',
@@ -12,7 +12,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '1.3.14'
+            'videoAndroid': '1.3.15'
     ]
     ext.getSecretProperty = { key, defaultValue ->
         def value = System.getenv(key)
@@ -37,8 +37,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
-        classpath 'com.google.gms:google-services:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.google.gms:google-services:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
Improvements

- Updated Android Gradle Plugin version to `3.1.0` and Gradle version to `4.4`
- Initial Connect message now includes Client version metadata.

Bug Fixes

- Fixed a bug where the SDK hangs if DNS resolution fails and the user does not initiate disconnect.
- The signaling Client no longer logs access tokens.
- Fixed a rare internal SDK teardown crash.
- Resolved an issue where the signaling Client could send too many UPDATE messages, or use too many
CPU cycles and disconnect from a Room.