### PR TITLE
Update to 3.0.0-preview1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Javadoc](https://img.shields.io/badge/javadoc-OK-blue.svg)](https://twilio.github.io/twilio-video-android/docs/latest/)
 
-> NOTE: These sample applications use the Twilio Video 2.x APIs. For examples using our 1.x APIs, please see
-the [1.x](https://github.com/twilio/video-quickstart-android/tree/1.x) branch.
+> NOTE: These sample applications use the Twilio Video 3.x APIs. For examples using our 2.x APIs, please see
+the [master](https://github.com/twilio/video-quickstart-android) branch.
 
 # Twilio Video Quickstart for Android
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     ext.kotlin_version = '1.2.31'
     ext.versions = [
+            'java': JavaVersion.VERSION_1_8,
             'compileSdk': 27,
             'buildTools': '27.0.3',
             'minSdk': 16,
@@ -12,7 +13,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '2.1.0'
+            'videoAndroid': '3.0.0-preview1'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->

--- a/exampleAdvancedCameraCapturer/build.gradle
+++ b/exampleAdvancedCameraCapturer/build.gradle
@@ -13,6 +13,11 @@ android {
         versionName "1.0"
     }
 
+    compileOptions {
+        sourceCompatibility versions.java
+        targetCompatibility versions.java
+    }
+
     buildTypes {
         release {
             minifyEnabled true

--- a/exampleAdvancedCameraCapturer/src/main/java/com/twilio/video/examples/advancedcameracapturer/AdvancedCameraCapturerActivity.java
+++ b/exampleAdvancedCameraCapturer/src/main/java/com/twilio/video/examples/advancedcameracapturer/AdvancedCameraCapturerActivity.java
@@ -42,34 +42,24 @@ public class AdvancedCameraCapturerActivity extends Activity {
     private CameraCapturer cameraCapturer;
     private LocalVideoTrack localVideoTrack;
     private boolean flashOn = false;
-    private final View.OnClickListener toggleFlashButtonClickListener = new View.OnClickListener() {
-        @Override public void onClick(View v) {
-            toggleFlash();
-        }
-    };
-    private final View.OnClickListener takePictureButtonClickListener = new View.OnClickListener() {
-        @Override public void onClick(View v) {
-            takePicture();
-        }
-    };
+    private final View.OnClickListener toggleFlashButtonClickListener = v -> toggleFlash();
+    private final View.OnClickListener takePictureButtonClickListener = v -> takePicture();
 
     /**
      * An example of a {@link CameraParameterUpdater} that shows how to toggle the flash of a
      * camera if supported by the device.
      */
-    private final CameraParameterUpdater flashToggler = new CameraParameterUpdater() {
-        @Override public void apply(Camera.Parameters parameters) {
-            if (parameters.getFlashMode() != null) {
-                String flashMode = flashOn ?
-                        Camera.Parameters.FLASH_MODE_OFF :
-                        Camera.Parameters.FLASH_MODE_TORCH;
-                parameters.setFlashMode(flashMode);
-                flashOn = !flashOn;
-            } else {
-                Toast.makeText(AdvancedCameraCapturerActivity.this,
-                        R.string.flash_not_supported,
-                        Toast.LENGTH_LONG).show();
-            }
+    private final CameraParameterUpdater flashToggler = parameters -> {
+        if (parameters.getFlashMode() != null) {
+            String flashMode = flashOn ?
+                    Camera.Parameters.FLASH_MODE_OFF :
+                    Camera.Parameters.FLASH_MODE_TORCH;
+            parameters.setFlashMode(flashMode);
+            flashOn = !flashOn;
+        } else {
+            Toast.makeText(AdvancedCameraCapturerActivity.this,
+                    R.string.flash_not_supported,
+                    Toast.LENGTH_LONG).show();
         }
     };
 
@@ -111,12 +101,7 @@ public class AdvancedCameraCapturerActivity extends Activity {
         pictureDialog = new AlertDialog.Builder(this)
                 .setView(pictureImageView)
                 .setTitle(null)
-                .setPositiveButton(R.string.close, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(final DialogInterface dialog, int which) {
-                        dialog.dismiss();
-                    }
-                }).create();
+                .setPositiveButton(R.string.close, (dialog, which) -> dialog.dismiss()).create();
 
         if (!checkPermissionForCamera()) {
             requestPermissionForCamera();

--- a/exampleCustomVideoCapturer/build.gradle
+++ b/exampleCustomVideoCapturer/build.gradle
@@ -13,6 +13,11 @@ android {
         versionName "1.0"
     }
 
+    compileOptions {
+        sourceCompatibility versions.java
+        targetCompatibility versions.java
+    }
+
     buildTypes {
         release {
             minifyEnabled true

--- a/exampleCustomVideoRenderer/build.gradle
+++ b/exampleCustomVideoRenderer/build.gradle
@@ -13,6 +13,11 @@ android {
         versionName "1.0"
     }
 
+    compileOptions {
+        sourceCompatibility versions.java
+        targetCompatibility versions.java
+    }
+
     buildTypes {
         release {
             minifyEnabled true

--- a/exampleCustomVideoRenderer/src/main/java/com/twilio/video/examples/customrenderer/CustomRendererVideoActivity.java
+++ b/exampleCustomVideoRenderer/src/main/java/com/twilio/video/examples/customrenderer/CustomRendererVideoActivity.java
@@ -85,12 +85,9 @@ public class CustomRendererVideoActivity extends Activity {
         snapshotVideoRenderer = new SnapshotVideoRenderer(snapshotImageView);
         localVideoTrack.addRenderer(localVideoView);
         localVideoTrack.addRenderer(snapshotVideoRenderer);
-        localVideoView.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                tapForSnapshotTextView.setVisibility(View.GONE);
-                snapshotVideoRenderer.takeSnapshot();
-            }
+        localVideoView.setOnClickListener(v -> {
+            tapForSnapshotTextView.setVisibility(View.GONE);
+            snapshotVideoRenderer.takeSnapshot();
         });
     }
 

--- a/exampleCustomVideoRenderer/src/main/java/com/twilio/video/examples/customrenderer/SnapshotVideoRenderer.java
+++ b/exampleCustomVideoRenderer/src/main/java/com/twilio/video/examples/customrenderer/SnapshotVideoRenderer.java
@@ -47,15 +47,12 @@ public class SnapshotVideoRenderer implements VideoRenderer {
             final Bitmap bitmap = i420Frame.yuvPlanes == null ?
                     captureBitmapFromTexture(i420Frame) :
                     captureBitmapFromYuvFrame(i420Frame);
-            handler.post(new Runnable() {
-                @Override
-                public void run() {
-                    // Update the bitmap of image view
-                    imageView.setImageBitmap(bitmap);
+            handler.post(() -> {
+                // Update the bitmap of image view
+                imageView.setImageBitmap(bitmap);
 
-                    // Frames must be released after rendering to free the native memory
-                    i420Frame.release();
-                }
+                // Frames must be released after rendering to free the native memory
+                i420Frame.release();
             });
         } else {
             i420Frame.release();

--- a/exampleDataTrack/build.gradle
+++ b/exampleDataTrack/build.gradle
@@ -25,6 +25,11 @@ android {
                 "${getSecretProperty("USE_TOKEN_SERVER", false)}")
     }
 
+    compileOptions {
+        sourceCompatibility versions.java
+        targetCompatibility versions.java
+    }
+
     buildTypes {
         release {
             minifyEnabled false

--- a/exampleDataTrack/src/main/java/com/twilio/video/examples/datatrack/CollaborativeDrawingView.java
+++ b/exampleDataTrack/src/main/java/com/twilio/video/examples/datatrack/CollaborativeDrawingView.java
@@ -99,12 +99,7 @@ public class CollaborativeDrawingView extends View {
         }
 
         // Invalidate the view to draw the new remote track event
-        post(new Runnable() {
-            @Override
-            public void run() {
-                invalidate();
-            }
-        });
+        post(this::invalidate);
     }
 
     /**
@@ -115,12 +110,7 @@ public class CollaborativeDrawingView extends View {
         path.reset();
 
         // Invalidate the view
-        post(new Runnable() {
-            @Override
-            public void run() {
-                invalidate();
-            }
-        });
+        post(this::invalidate);
     }
 
     /**
@@ -133,12 +123,7 @@ public class CollaborativeDrawingView extends View {
         remoteParticipantPalettes.remove(remoteParticipant);
 
         // Invalidate the view
-        post(new Runnable() {
-            @Override
-            public void run() {
-                invalidate();
-            }
-        });
+        post(this::invalidate);
     }
 
     @Override

--- a/exampleDataTrack/src/main/java/com/twilio/video/examples/datatrack/DataTrackActivity.java
+++ b/exampleDataTrack/src/main/java/com/twilio/video/examples/datatrack/DataTrackActivity.java
@@ -183,18 +183,15 @@ public class DataTrackActivity extends AppCompatActivity {
     }
 
     private View.OnClickListener connectButtonClickListener() {
-        return new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                if (connectButton.getText().equals(getString(R.string.connect))) {
-                    String roomName = roomEditText.getText().toString();
-                    roomEditText.setEnabled(false);
-                    connectButton.setEnabled(false);
-                    snackbar.setText("Connecting to " + roomName);
-                    connectToRoom(roomName);
-                } else {
-                    disconnectFromRoom();
-                }
+        return view -> {
+            if (connectButton.getText().equals(getString(R.string.connect))) {
+                String roomName = roomEditText.getText().toString();
+                roomEditText.setEnabled(false);
+                connectButton.setEnabled(false);
+                snackbar.setText("Connecting to " + roomName);
+                connectToRoom(roomName);
+            } else {
+                disconnectFromRoom();
             }
         };
     }
@@ -231,23 +228,20 @@ public class DataTrackActivity extends AppCompatActivity {
                 .load(String.format("%s?identity=%s", ACCESS_TOKEN_SERVER,
                         UUID.randomUUID().toString()))
                 .asString()
-                .setCallback(new FutureCallback<String>() {
-                    @Override
-                    public void onCompleted(Exception e, String token) {
-                        boolean requestSucceeded = e == null;
+                .setCallback((e, token) -> {
+                    boolean requestSucceeded = e == null;
 
-                        if (requestSucceeded) {
-                            DataTrackActivity.this.accessToken = token;
-                        } else {
-                            Toast.makeText(DataTrackActivity.this,
-                                    R.string.error_retrieving_access_token, Toast.LENGTH_LONG)
-                                    .show();
-                        }
-
-                        // Setup UI based on request result
-                        roomEditText.setEnabled(requestSucceeded);
-                        connectButton.setEnabled(requestSucceeded);
+                    if (requestSucceeded) {
+                        DataTrackActivity.this.accessToken = token;
+                    } else {
+                        Toast.makeText(DataTrackActivity.this,
+                                R.string.error_retrieving_access_token, Toast.LENGTH_LONG)
+                                .show();
                     }
+
+                    // Setup UI based on request result
+                    roomEditText.setEnabled(requestSucceeded);
+                    connectButton.setEnabled(requestSucceeded);
                 });
     }
 
@@ -341,13 +335,8 @@ public class DataTrackActivity extends AppCompatActivity {
              * invocation of setting the listener onto our dedicated data track message thread.
              */
             if (remoteDataTrackPublication.isTrackSubscribed()) {
-                dataTrackMessageThreadHandler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        addRemoteDataTrack(remoteParticipant,
-                                remoteDataTrackPublication.getRemoteDataTrack());
-                    }
-                });
+                dataTrackMessageThreadHandler.post(() -> addRemoteDataTrack(remoteParticipant,
+                        remoteDataTrackPublication.getRemoteDataTrack()));
             }
         }
     }
@@ -421,12 +410,7 @@ public class DataTrackActivity extends AppCompatActivity {
                  * Data track messages are received on the thread that calls setListener. Post the
                  * invocation of setting the listener onto our dedicated data track message thread.
                  */
-                dataTrackMessageThreadHandler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        addRemoteDataTrack(remoteParticipant, remoteDataTrack);
-                    }
-                });
+                dataTrackMessageThreadHandler.post(() -> addRemoteDataTrack(remoteParticipant, remoteDataTrack));
             }
 
             @Override

--- a/exampleScreenCapturer/build.gradle
+++ b/exampleScreenCapturer/build.gradle
@@ -15,6 +15,10 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
     }
+    compileOptions {
+        sourceCompatibility versions.java
+        targetCompatibility versions.java
+    }
     buildTypes {
         release {
             minifyEnabled false

--- a/exampleVideoInvite/build.gradle
+++ b/exampleVideoInvite/build.gradle
@@ -18,6 +18,11 @@ android {
                 "\"${getSecretProperty("TWILIO_SDK_STARTER_SERVER_URL", "TWILIO_SDK_STARTER_SERVER_URL")}\"")
     }
 
+    compileOptions {
+        sourceCompatibility versions.java
+        targetCompatibility versions.java
+    }
+
     buildTypes {
         release {
             minifyEnabled false

--- a/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
+++ b/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
@@ -883,129 +883,101 @@ public class VideoInviteActivity extends AppCompatActivity {
     }
 
     private DialogInterface.OnClickListener connectClickListener(final EditText roomEditText) {
-        return new DialogInterface.OnClickListener() {
-
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                final String roomName = roomEditText.getText().toString();
-                /*
-                 * Connect to room
-                 */
-                connectToRoom(roomName);
-                /*
-                 * Notify other participants to join the room
-                 */
-                VideoInviteActivity.this.notify(roomName);
-            }
+        return (dialog, which) -> {
+            final String roomName = roomEditText.getText().toString();
+            /*
+             * Connect to room
+             */
+            connectToRoom(roomName);
+            /*
+             * Notify other participants to join the room
+             */
+            VideoInviteActivity.this.notify(roomName);
         };
     }
 
     private DialogInterface.OnClickListener videoNotificationConnectClickListener(final EditText roomEditText) {
-        return new DialogInterface.OnClickListener() {
-
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                /*
-                 * Connect to room
-                 */
-                connectToRoom(roomEditText.getText().toString());
-            }
+        return (dialog, which) -> {
+            /*
+             * Connect to room
+             */
+            connectToRoom(roomEditText.getText().toString());
         };
     }
 
     private View.OnClickListener disconnectClickListener() {
-        return new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                /*
-                 * Disconnect from room
-                 */
-                if (room != null) {
-                    room.disconnect();
-                }
-                intializeUI();
+        return v -> {
+            /*
+             * Disconnect from room
+             */
+            if (room != null) {
+                room.disconnect();
             }
+            intializeUI();
         };
     }
 
     private View.OnClickListener connectActionClickListener() {
-        return new View.OnClickListener(){
-            @Override
-            public void onClick(View v) {
-                showConnectDialog();
-            }
-        };
+        return v -> showConnectDialog();
     }
 
     private DialogInterface.OnClickListener cancelConnectDialogClickListener() {
-        return new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                intializeUI();
-                alertDialog.dismiss();
-            }
+        return (dialog, which) -> {
+            intializeUI();
+            alertDialog.dismiss();
         };
     }
 
     private View.OnClickListener switchCameraClickListener() {
-        return new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (cameraCapturer != null) {
-                    CameraSource cameraSource = cameraCapturer.getCameraSource();
-                    cameraCapturer.switchCamera();
-                    if (thumbnailVideoView.getVisibility() == View.VISIBLE) {
-                        thumbnailVideoView.setMirror(cameraSource == CameraSource.BACK_CAMERA);
-                    } else {
-                        primaryVideoView.setMirror(cameraSource == CameraSource.BACK_CAMERA);
-                    }
+        return v -> {
+            if (cameraCapturer != null) {
+                CameraSource cameraSource = cameraCapturer.getCameraSource();
+                cameraCapturer.switchCamera();
+                if (thumbnailVideoView.getVisibility() == View.VISIBLE) {
+                    thumbnailVideoView.setMirror(cameraSource == CameraSource.BACK_CAMERA);
+                } else {
+                    primaryVideoView.setMirror(cameraSource == CameraSource.BACK_CAMERA);
                 }
             }
         };
     }
 
     private View.OnClickListener localVideoClickListener() {
-        return new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                /*
-                 * Enable/disable the local video track
-                 */
-                if (localVideoTrack != null) {
-                    boolean enable = !localVideoTrack.isEnabled();
-                    localVideoTrack.enable(enable);
-                    int icon;
-                    if (enable) {
-                        icon = R.drawable.ic_videocam_white_24dp;
-                        switchCameraActionFab.show();
-                    } else {
-                        icon = R.drawable.ic_videocam_off_black_24dp;
-                        switchCameraActionFab.hide();
-                    }
-                    localVideoActionFab.setImageDrawable(
-                            ContextCompat.getDrawable(VideoInviteActivity.this, icon));
+        return v -> {
+            /*
+             * Enable/disable the local video track
+             */
+            if (localVideoTrack != null) {
+                boolean enable = !localVideoTrack.isEnabled();
+                localVideoTrack.enable(enable);
+                int icon;
+                if (enable) {
+                    icon = R.drawable.ic_videocam_white_24dp;
+                    switchCameraActionFab.show();
+                } else {
+                    icon = R.drawable.ic_videocam_off_black_24dp;
+                    switchCameraActionFab.hide();
                 }
+                localVideoActionFab.setImageDrawable(
+                        ContextCompat.getDrawable(VideoInviteActivity.this, icon));
             }
         };
     }
 
     private View.OnClickListener muteClickListener() {
-        return new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                /*
-                 * Enable/disable the local audio track. The results of this operation are
-                 * signaled to other Participants in the same Room. When an audio track is
-                 * disabled, the audio is muted.
-                 */
-                if (localAudioTrack != null) {
-                    boolean enable = !localAudioTrack.isEnabled();
-                    localAudioTrack.enable(enable);
-                    int icon = enable ?
-                            R.drawable.ic_mic_white_24dp : R.drawable.ic_mic_off_black_24dp;
-                    muteActionFab.setImageDrawable(ContextCompat.getDrawable(
-                            VideoInviteActivity.this, icon));
-                }
+        return v -> {
+            /*
+             * Enable/disable the local audio track. The results of this operation are
+             * signaled to other Participants in the same Room. When an audio track is
+             * disabled, the audio is muted.
+             */
+            if (localAudioTrack != null) {
+                boolean enable = !localAudioTrack.isEnabled();
+                localAudioTrack.enable(enable);
+                int icon = enable ?
+                        R.drawable.ic_mic_white_24dp : R.drawable.ic_mic_off_black_24dp;
+                muteActionFab.setImageDrawable(ContextCompat.getDrawable(
+                        VideoInviteActivity.this, icon));
             }
         };
     }
@@ -1039,10 +1011,7 @@ public class VideoInviteActivity extends AppCompatActivity {
                             .setAudioAttributes(playbackAttributes)
                             .setAcceptsDelayedFocusGain(true)
                             .setOnAudioFocusChangeListener(
-                                    new AudioManager.OnAudioFocusChangeListener() {
-                                        @Override
-                                        public void onAudioFocusChange(int i) { }
-                                    })
+                                    i -> { })
                             .build();
             audioManager.requestAudioFocus(focusRequest);
         } else {

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -23,6 +23,11 @@ android {
                 "${getSecretProperty("USE_TOKEN_SERVER", false)}")
     }
 
+    compileOptions {
+        sourceCompatibility versions.java
+        targetCompatibility versions.java
+    }
+
     buildTypes {
         release {
             minifyEnabled true

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/SettingsActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/SettingsActivity.java
@@ -150,12 +150,9 @@ public class SettingsActivity extends AppCompatActivity {
             preference.setEntryValues(codecStrings);
             preference.setValue(value);
             preference.setSummary(value);
-            preference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-                @Override
-                public boolean onPreferenceChange(Preference preference, Object newValue) {
-                    preference.setSummary(newValue.toString());
-                    return true;
-                }
+            preference.setOnPreferenceChangeListener((preference1, newValue) -> {
+                preference1.setSummary(newValue.toString());
+                return true;
             });
         }
 
@@ -167,12 +164,9 @@ public class SettingsActivity extends AppCompatActivity {
             // Set layout with input type number for edit text
             editTextPreference.setDialogLayoutResource(R.layout.preference_dialog_number_edittext);
             editTextPreference.setSummary(value);
-            editTextPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-                @Override
-                public boolean onPreferenceChange(Preference preference, Object newValue) {
-                    preference.setSummary(newValue.toString());
-                    return true;
-                }
+            editTextPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+                preference.setSummary(newValue.toString());
+                return true;
             });
         }
     }

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -958,111 +958,87 @@ public class VideoActivity extends AppCompatActivity {
     }
 
     private DialogInterface.OnClickListener connectClickListener(final EditText roomEditText) {
-        return new DialogInterface.OnClickListener() {
-
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                /*
-                 * Connect to room
-                 */
-                connectToRoom(roomEditText.getText().toString());
-            }
+        return (dialog, which) -> {
+            /*
+             * Connect to room
+             */
+            connectToRoom(roomEditText.getText().toString());
         };
     }
 
     private View.OnClickListener disconnectClickListener() {
-        return new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                /*
-                 * Disconnect from room
-                 */
-                if (room != null) {
-                    room.disconnect();
-                }
-                intializeUI();
+        return v -> {
+            /*
+             * Disconnect from room
+             */
+            if (room != null) {
+                room.disconnect();
             }
+            intializeUI();
         };
     }
 
     private View.OnClickListener connectActionClickListener() {
-        return new View.OnClickListener(){
-            @Override
-            public void onClick(View v) {
-                showConnectDialog();
-            }
-        };
+        return v -> showConnectDialog();
     }
 
     private DialogInterface.OnClickListener cancelConnectDialogClickListener() {
-        return new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                intializeUI();
-                connectDialog.dismiss();
-            }
+        return (dialog, which) -> {
+            intializeUI();
+            connectDialog.dismiss();
         };
     }
 
     private View.OnClickListener switchCameraClickListener() {
-        return new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (cameraCapturerCompat != null) {
-                    CameraSource cameraSource = cameraCapturerCompat.getCameraSource();
-                    cameraCapturerCompat.switchCamera();
-                    if (thumbnailVideoView.getVisibility() == View.VISIBLE) {
-                        thumbnailVideoView.setMirror(cameraSource == CameraSource.BACK_CAMERA);
-                    } else {
-                        primaryVideoView.setMirror(cameraSource == CameraSource.BACK_CAMERA);
-                    }
+        return v -> {
+            if (cameraCapturerCompat != null) {
+                CameraSource cameraSource = cameraCapturerCompat.getCameraSource();
+                cameraCapturerCompat.switchCamera();
+                if (thumbnailVideoView.getVisibility() == View.VISIBLE) {
+                    thumbnailVideoView.setMirror(cameraSource == CameraSource.BACK_CAMERA);
+                } else {
+                    primaryVideoView.setMirror(cameraSource == CameraSource.BACK_CAMERA);
                 }
             }
         };
     }
 
     private View.OnClickListener localVideoClickListener() {
-        return new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                /*
-                 * Enable/disable the local video track
-                 */
-                if (localVideoTrack != null) {
-                    boolean enable = !localVideoTrack.isEnabled();
-                    localVideoTrack.enable(enable);
-                    int icon;
-                    if (enable) {
-                        icon = R.drawable.ic_videocam_white_24dp;
-                        switchCameraActionFab.show();
-                    } else {
-                        icon = R.drawable.ic_videocam_off_black_24dp;
-                        switchCameraActionFab.hide();
-                    }
-                    localVideoActionFab.setImageDrawable(
-                            ContextCompat.getDrawable(VideoActivity.this, icon));
+        return v -> {
+            /*
+             * Enable/disable the local video track
+             */
+            if (localVideoTrack != null) {
+                boolean enable = !localVideoTrack.isEnabled();
+                localVideoTrack.enable(enable);
+                int icon;
+                if (enable) {
+                    icon = R.drawable.ic_videocam_white_24dp;
+                    switchCameraActionFab.show();
+                } else {
+                    icon = R.drawable.ic_videocam_off_black_24dp;
+                    switchCameraActionFab.hide();
                 }
+                localVideoActionFab.setImageDrawable(
+                        ContextCompat.getDrawable(VideoActivity.this, icon));
             }
         };
     }
 
     private View.OnClickListener muteClickListener() {
-        return new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                /*
-                 * Enable/disable the local audio track. The results of this operation are
-                 * signaled to other Participants in the same Room. When an audio track is
-                 * disabled, the audio is muted.
-                 */
-                if (localAudioTrack != null) {
-                    boolean enable = !localAudioTrack.isEnabled();
-                    localAudioTrack.enable(enable);
-                    int icon = enable ?
-                            R.drawable.ic_mic_white_24dp : R.drawable.ic_mic_off_black_24dp;
-                    muteActionFab.setImageDrawable(ContextCompat.getDrawable(
-                            VideoActivity.this, icon));
-                }
+        return v -> {
+            /*
+             * Enable/disable the local audio track. The results of this operation are
+             * signaled to other Participants in the same Room. When an audio track is
+             * disabled, the audio is muted.
+             */
+            if (localAudioTrack != null) {
+                boolean enable = !localAudioTrack.isEnabled();
+                localAudioTrack.enable(enable);
+                int icon = enable ?
+                        R.drawable.ic_mic_white_24dp : R.drawable.ic_mic_off_black_24dp;
+                muteActionFab.setImageDrawable(ContextCompat.getDrawable(
+                        VideoActivity.this, icon));
             }
         };
     }
@@ -1072,16 +1048,13 @@ public class VideoActivity extends AppCompatActivity {
                 .load(String.format("%s?identity=%s", ACCESS_TOKEN_SERVER,
                         UUID.randomUUID().toString()))
                 .asString()
-                .setCallback(new FutureCallback<String>() {
-                    @Override
-                    public void onCompleted(Exception e, String token) {
-                        if (e == null) {
-                            VideoActivity.this.accessToken = token;
-                        } else {
-                            Toast.makeText(VideoActivity.this,
-                                    R.string.error_retrieving_access_token, Toast.LENGTH_LONG)
-                                    .show();
-                        }
+                .setCallback((e, token) -> {
+                    if (e == null) {
+                        VideoActivity.this.accessToken = token;
+                    } else {
+                        Toast.makeText(VideoActivity.this,
+                                R.string.error_retrieving_access_token, Toast.LENGTH_LONG)
+                                .show();
                     }
                 });
     }
@@ -1121,10 +1094,7 @@ public class VideoActivity extends AppCompatActivity {
                             .setAudioAttributes(playbackAttributes)
                             .setAcceptsDelayedFocusGain(true)
                             .setOnAudioFocusChangeListener(
-                                    new AudioManager.OnAudioFocusChangeListener() {
-                                        @Override
-                                        public void onAudioFocusChange(int i) { }
-                                    })
+                                    i -> { })
                             .build();
             audioManager.requestAudioFocus(focusRequest);
         } else {

--- a/quickstartKotlin/build.gradle
+++ b/quickstartKotlin/build.gradle
@@ -24,6 +24,11 @@ android {
                 "${getSecretProperty("USE_TOKEN_SERVER", false)}")
     }
 
+    compileOptions {
+        sourceCompatibility versions.java
+        targetCompatibility versions.java
+    }
+
     buildTypes {
         release {
             minifyEnabled true

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
@@ -113,7 +113,7 @@ class VideoActivity : AppCompatActivity() {
             title = room.name
 
             // Only one participant is supported
-            room.remoteParticipants.firstOrNull()?.let { addRemoteParticipant(it) }
+            room.remoteParticipants?.firstOrNull()?.let { addRemoteParticipant(it) }
         }
 
         override fun onConnectFailure(room: Room, e: TwilioException) {


### PR DESCRIPTION
Improvements

- Upgraded to WebRTC 67.
- Upgraded to Java 8. Add the following snippet to your `build.gradle` to enable Java 8
features required to build the 3.x Video Android SDK:

        android {
            compileOptions {
                sourceCompatibility 1.8
                targetCompatibility 1.8
            }
        }
- Added @Nullable and @NonNull to all public API fields, methods, and interfaces.
- Updated internal capturer pipeline for `CameraCapturer`, `ScreenCapturer`, and `Camera2Capturer`.
- Upgraded to Android NDK 16.

---

Quickstart Updates

- Upgraded modules to use Java 8.