### PR TITLE
Update to 2.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '2.2.0'
+            'videoAndroid': '2.2.1'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->


### PR DESCRIPTION
Improvements

- Adding a null video/audio codec to `ConnectOptions` will now throw an exception
- Switched CI provider for build, test, and release pipeline.