### PR TITLE
Upgrade to 3.0.0-preview3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '3.0.0-preview2'
+            'videoAndroid': '3.0.0-preview3'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->

--- a/exampleDataTrack/src/main/java/com/twilio/video/examples/datatrack/DataTrackActivity.java
+++ b/exampleDataTrack/src/main/java/com/twilio/video/examples/datatrack/DataTrackActivity.java
@@ -30,7 +30,6 @@ import com.twilio.video.RemoteParticipant;
 import com.twilio.video.RemoteVideoTrack;
 import com.twilio.video.RemoteVideoTrackPublication;
 import com.twilio.video.Room;
-import com.twilio.video.RoomState;
 import com.twilio.video.TwilioException;
 import com.twilio.video.Video;
 
@@ -126,7 +125,7 @@ public class DataTrackActivity extends AppCompatActivity {
          * Always disconnect from the room before leaving the Activity to
          * ensure any memory allocated to the Room resource is freed.
          */
-        if (room != null && room.getState() != RoomState.DISCONNECTED) {
+        if (room != null && room.getState() != Room.State.DISCONNECTED) {
             room.disconnect();
             disconnectedFromOnDestroy = true;
         }

--- a/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
+++ b/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
@@ -46,7 +46,6 @@ import com.twilio.video.RemoteParticipant;
 import com.twilio.video.RemoteVideoTrack;
 import com.twilio.video.RemoteVideoTrackPublication;
 import com.twilio.video.Room;
-import com.twilio.video.RoomState;
 import com.twilio.video.TwilioException;
 import com.twilio.video.Video;
 import com.twilio.video.VideoRenderer;
@@ -392,7 +391,7 @@ public class VideoInviteActivity extends AppCompatActivity {
          * Always disconnect from the room before leaving the Activity to
          * ensure any memory allocated to the Room resource is freed.
          */
-        if (room != null && room.getState() != RoomState.DISCONNECTED) {
+        if (room != null && room.getState() != Room.State.DISCONNECTED) {
             room.disconnect();
             disconnectedFromOnDestroy = true;
         }

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -49,7 +49,6 @@ import com.twilio.video.RemoteDataTrackPublication;
 import com.twilio.video.RemoteParticipant;
 import com.twilio.video.RemoteVideoTrack;
 import com.twilio.video.RemoteVideoTrackPublication;
-import com.twilio.video.RoomState;
 import com.twilio.video.Video;
 import com.twilio.video.VideoCodec;
 import com.twilio.video.VideoRenderer;
@@ -324,7 +323,7 @@ public class VideoActivity extends AppCompatActivity {
          * Always disconnect from the room before leaving the Activity to
          * ensure any memory allocated to the Room resource is freed.
          */
-        if (room != null && room.getState() != RoomState.DISCONNECTED) {
+        if (room != null && room.getState() != Room.State.DISCONNECTED) {
             room.disconnect();
             disconnectedFromOnDestroy = true;
         }


### PR DESCRIPTION
Enhancements

- The signaling Client has been updated to support version 2 of the Room Signaling Protocol (RSP).
- Added ECS debugging support at the signaling layer that will help in troubleshooting ice server related issues.
- Introduced a safer threading model in the signaling layer that prevents occasional crashes and missing Track subscription events.
- The SDK no longer waits for pending events when closing a PeerConnection speeding up the teardown process.
- Moved `RoomState` enum to `Room.State`.
- `onDisconnected` will now return a unique error code when the Room is completed via the REST API.

Bug Fixes

- The signaling Client is more lenient when encountering unexpected RSP messages.
- Resolved a scenario where an ICE restart could be ignored after experiencing signaling glare.

Known issues

- Network handoff, and subsequent connection renegotiation is not supported for IPv6 networks [#72](https://github.com/twilio/video-quickstart-android/issues/72)
- Participant disconnect event can take up to 120 seconds to occur [#80](https://github.com/twilio/video-quickstart-android/issues/80) [#73](https://github.com/twilio/video-quickstart-android/issues/73)
- Codec preferences do not function correctly in a hybrid codec Group Room with the following
codecs:
    - ISAC
    - PCMA
    - G722
    - VP9