### PR TITLE
Upgrade to 3.0.0-beta1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '3.0.0-preview3'
+            'videoAndroid': '3.0.0-beta1'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->


### PR DESCRIPTION
### 3.0.0-beta1

- `3.0.0-preview3` has been promoted to `3.0.0-beta1`. The `3.0.0` API is now final and will only receive bug fixes and improvements until `3.0.0` is officially released.

Enhancements

- The signaling Client has been updated to support version 2 of the Room Signaling Protocol (RSP).
- Added ECS debugging support at the signaling layer that will help in troubleshooting ice server related issues.
- Introduced a safer threading model in the signaling layer that prevents occasional crashes and missing Track subscription events.
- The SDK no longer waits for pending events when closing a PeerConnection speeding up the teardown process.
- Moved `RoomState` enum to `Room.State`.
- `onDisconnected` will now return a unique error code when the Room is completed via the REST API.

Bug Fixes

- The signaling Client is more lenient when encountering unexpected RSP messages.
- Resolved a scenario where an ICE restart could be ignored after experiencing signaling glare.

Known issues

- Network handoff, and subsequent connection renegotiation is not supported for IPv6 networks [#72](https://github.com/twilio/video-quickstart-android/issues/72)
- Participant disconnect event can take up to 120 seconds to occur [#80](https://github.com/twilio/video-quickstart-android/issues/80) [#73](https://github.com/twilio/video-quickstart-android/issues/73)
- Codec preferences do not function correctly in a hybrid codec Group Room with the following
codecs:
    - ISAC
    - PCMA
    - G722
    - VP9