### PR TITLE
3.0.0 Release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '3.0.0-beta1'
+            'videoAndroid': '3.0.0'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
@@ -812,7 +812,7 @@ class VideoActivity : AppCompatActivity() {
         Ion.with(this)
                 .load("$ACCESS_TOKEN_SERVER?identity=${UUID.randomUUID()}")
                 .asString()
-                .setCallback({ e, token ->
+                .setCallback { e, token ->
                     if (e == null) {
                         this@VideoActivity.accessToken = token
                     } else {
@@ -820,7 +820,7 @@ class VideoActivity : AppCompatActivity() {
                                 R.string.error_retrieving_access_token, Toast.LENGTH_LONG)
                                 .show()
                     }
-                })
+                }
     }
 
     private fun configureAudio(enable: Boolean) {


### PR DESCRIPTION
`3.0.0-beta1` has been promoted to `3.0.0`. The `3.x` SDK is now Generally Available (GA). The `1.x` and `2.x` Video Android SDK remain GA but will only receive critical bug fixes moving forward.

This PR also includes merge from master in preparation for a 3.x -> master merge.