### PR TITLE
Update to Video Android 3.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '3.0.0'
+            'videoAndroid': '3.1.0'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->


### PR DESCRIPTION
3.1.0

Improvements

- Added `IceCandidatePairStats` to `StatsReport` which gives insight into local and remote ice candidates
- Reduced signaling traffic in Group Rooms when communicating with an ICE-lite agent.

 Bug Fixes

- Fixed a bug where the client could send additional ICE candidates after signaling the end of candidates, or mark candidates with a username from a future offer.

Known issues

- Network handoff, and subsequent connection renegotiation is not supported for IPv6 networks [#72](https://github.com/twilio/video-quickstart-android/issues/72)
- Participant disconnect event can take up to 120 seconds to occur [#80](https://github.com/twilio/video-quickstart-android/issues/80) [#73](https://github.com/twilio/video-quickstart-android/issues/73)
- The SDK is not side-by-side compatible with other WebRTC based libraries [#340](https://github.com/twilio/video-quickstart-android/issues/340)
- Codec preferences do not function correctly in a hybrid codec Group Room with the following
codecs:
    - ISAC
    - PCMA
    - G722
    - VP9