### PR TITLE
Update to video android 3.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '3.1.0'
+            'videoAndroid': '3.2.0'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->


### PR DESCRIPTION
### 3.2.0
Improvements

- Added `IceCandidateStats` to `StatsReport` which gives insight into individual ice candidates
- Removed forced ice-restart when synced responses are processed
- Improved the detection of, and recovery from media connection failures. Worst case recovery times have been reduced by up to 10 seconds.
- Added handle to native audio track. This will assist developers when using advanced features like audio track sink.

Known issues

- Network handoff, and subsequent connection renegotiation is not supported for IPv6 networks [#72](https://github.com/twilio/video-quickstart-android/issues/72)
- Participant disconnect event can take up to 120 seconds to occur [#80](https://github.com/twilio/video-quickstart-android/issues/80) [#73](https://github.com/twilio/video-quickstart-android/issues/73)
- The SDK is not side-by-side compatible with other WebRTC based libraries [#340](https://github.com/twilio/video-quickstart-android/issues/340)
- Codec preferences do not function correctly in a hybrid codec Group Room with the following
codecs:
    - ISAC
    - PCMA
    - G722
    - VP9

Size Report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| universal       | 22.3MB          |
| armeabi-v7a     | 5MB             |
| arm64-v8a       | 5.7MB           |
| x86             | 6MB             |
| x86_64          | 6.2MB           |
