### PR TITLE
Update to 4.0.0 Release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '3.2.2'
+            'videoAndroid': '4.0.0'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->

--- a/exampleDataTrack/src/main/java/com/twilio/video/examples/datatrack/DataTrackActivity.java
+++ b/exampleDataTrack/src/main/java/com/twilio/video/examples/datatrack/DataTrackActivity.java
@@ -320,6 +320,23 @@ public class DataTrackActivity extends AppCompatActivity {
             public void onRecordingStopped(Room room) {
 
             }
+
+            @Override
+            public void onReconnecting(Room room, TwilioException exception) {
+                Toast.makeText(DataTrackActivity.this,
+                        String.format("Reconnecting to room %s, exception = %s", room.getName(),
+                                exception.getMessage()),
+                        Toast.LENGTH_SHORT)
+                        .show();
+            }
+
+            @Override
+            public void onReconnected(Room room) {
+                Toast.makeText(DataTrackActivity.this,
+                        String.format("Reconnected to room %s", room.getName()),
+                        Toast.LENGTH_SHORT)
+                        .show();
+            }
         };
     }
 

--- a/exampleDataTrack/src/main/java/com/twilio/video/examples/datatrack/DataTrackActivity.java
+++ b/exampleDataTrack/src/main/java/com/twilio/video/examples/datatrack/DataTrackActivity.java
@@ -126,9 +126,14 @@ public class DataTrackActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
 
+        /*
+         * Update reconnecting UI
+         */
         if (room != null) {
-            Room.State state = room.getState();
-            reconnectingProgressBar.setVisibility((state != Room.State.RECONNECTING) ? View.GONE : View.VISIBLE);
+            reconnectingProgressBar.setVisibility((room.getState() != Room.State.RECONNECTING) ?
+                    View.GONE :
+                    View.VISIBLE);
+            snackbar.setText("Connected to " + room.getName());
         }
     }
 

--- a/exampleDataTrack/src/main/java/com/twilio/video/examples/datatrack/DataTrackActivity.java
+++ b/exampleDataTrack/src/main/java/com/twilio/video/examples/datatrack/DataTrackActivity.java
@@ -16,6 +16,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.ProgressBar;
 import android.widget.Toast;
 
 import com.koushikdutta.async.future.FutureCallback;
@@ -90,6 +91,7 @@ public class DataTrackActivity extends AppCompatActivity {
     private Snackbar snackbar;
     private EditText roomEditText;
     private Button connectButton;
+    private ProgressBar reconnectingProgressBar;
     private CollaborativeDrawingView collaborativeDrawingView;
 
     @Override
@@ -111,12 +113,23 @@ public class DataTrackActivity extends AppCompatActivity {
         snackbar = Snackbar.make(containerLayout,
                 R.string.connect_to_share,
                 Snackbar.LENGTH_INDEFINITE);
+        reconnectingProgressBar = findViewById(R.id.reconnecting_progress_bar);
         setSupportActionBar(toolbar);
         snackbar.show();
         initializeUi();
 
         // Set access token
         setAccessToken();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        if (room != null) {
+            Room.State state = room.getState();
+            reconnectingProgressBar.setVisibility((state != Room.State.RECONNECTING) ? View.GONE : View.VISIBLE);
+        }
     }
 
     @Override
@@ -291,6 +304,7 @@ public class DataTrackActivity extends AppCompatActivity {
 
                     initializeUi();
                 }
+                reconnectingProgressBar.setVisibility(View.GONE);
             }
 
             @Override
@@ -323,19 +337,14 @@ public class DataTrackActivity extends AppCompatActivity {
 
             @Override
             public void onReconnecting(Room room, TwilioException exception) {
-                Toast.makeText(DataTrackActivity.this,
-                        String.format("Reconnecting to room %s, exception = %s", room.getName(),
-                                exception.getMessage()),
-                        Toast.LENGTH_SHORT)
-                        .show();
+                reconnectingProgressBar.setVisibility(View.VISIBLE);
+                snackbar.setText("Reconnecting to " + room.getName());
             }
 
             @Override
             public void onReconnected(Room room) {
-                Toast.makeText(DataTrackActivity.this,
-                        String.format("Reconnected to room %s", room.getName()),
-                        Toast.LENGTH_SHORT)
-                        .show();
+                reconnectingProgressBar.setVisibility(View.GONE);
+                snackbar.setText("Connected to " + room.getName());
             }
         };
     }

--- a/exampleDataTrack/src/main/res/layout/activity_data_track.xml
+++ b/exampleDataTrack/src/main/res/layout/activity_data_track.xml
@@ -13,6 +13,15 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
 
+    <ProgressBar
+        android:id="@+id/reconnecting_progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:indeterminate="true"
+        style="?android:attr/progressBarStyleLarge"
+        android:visibility="gone" />
+
     <android.support.design.widget.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">

--- a/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
+++ b/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
@@ -744,6 +744,16 @@ public class VideoInviteActivity extends AppCompatActivity {
                  * recording is only available in our Group Rooms developer preview.
                  */
             }
+
+            @Override
+            public void onReconnecting(Room room, TwilioException exception) {
+                statusTextView.setText("Reconnecting");
+            }
+
+            @Override
+            public void onReconnected(Room room) {
+                statusTextView.setText("Reconnected");
+            }
         };
     }
 

--- a/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
+++ b/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
@@ -362,10 +362,14 @@ public class VideoInviteActivity extends AppCompatActivity {
             }
         }
 
+        /*
+         * Update reconnecting UI
+         */
         if (room != null) {
             reconnectingProgressBar.setVisibility((room.getState() != Room.State.RECONNECTING) ?
                     View.GONE :
                     View.VISIBLE);
+            statusTextView.setText("Connected to " + room.getName());
         }
     }
 

--- a/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
+++ b/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
@@ -27,6 +27,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.EditText;
+import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -150,6 +151,7 @@ public class VideoInviteActivity extends AppCompatActivity {
     private FloatingActionButton switchCameraActionFab;
     private FloatingActionButton localVideoActionFab;
     private FloatingActionButton muteActionFab;
+    private ProgressBar reconnectingProgressBar;
     private android.support.v7.app.AlertDialog alertDialog;
     private AudioManager audioManager;
     private String remoteParticipantIdentity;
@@ -164,15 +166,16 @@ public class VideoInviteActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_video);
 
-        primaryVideoView = (VideoView) findViewById(R.id.primary_video_view);
-        thumbnailVideoView = (VideoView) findViewById(R.id.thumbnail_video_view);
-        statusTextView = (TextView) findViewById(R.id.status_textview);
-        identityTextView = (TextView) findViewById(R.id.identity_textview);
+        primaryVideoView = findViewById(R.id.primary_video_view);
+        thumbnailVideoView = findViewById(R.id.thumbnail_video_view);
+        statusTextView = findViewById(R.id.status_textview);
+        identityTextView = findViewById(R.id.identity_textview);
 
-        connectActionFab = (FloatingActionButton) findViewById(R.id.connect_action_fab);
-        switchCameraActionFab = (FloatingActionButton) findViewById(R.id.switch_camera_action_fab);
-        localVideoActionFab = (FloatingActionButton) findViewById(R.id.local_video_action_fab);
-        muteActionFab = (FloatingActionButton) findViewById(R.id.mute_action_fab);
+        connectActionFab = findViewById(R.id.connect_action_fab);
+        switchCameraActionFab = findViewById(R.id.switch_camera_action_fab);
+        localVideoActionFab = findViewById(R.id.local_video_action_fab);
+        muteActionFab = findViewById(R.id.mute_action_fab);
+        reconnectingProgressBar = findViewById(R.id.reconnecting_progress_bar);
 
         /*
          * Hide the connect button until we successfully register with Twilio Notify
@@ -187,7 +190,7 @@ public class VideoInviteActivity extends AppCompatActivity {
         /*
          * Needed for setting/abandoning audio focus during call
          */
-        audioManager = (AudioManager)getSystemService(Context.AUDIO_SERVICE);
+        audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
         audioManager.setSpeakerphoneOn(true);
 
         /*
@@ -357,6 +360,12 @@ public class VideoInviteActivity extends AppCompatActivity {
             if (localParticipant != null) {
                 localParticipant.publishTrack(localVideoTrack);
             }
+        }
+
+        if (room != null) {
+            reconnectingProgressBar.setVisibility((room.getState() != Room.State.RECONNECTING) ?
+                    View.GONE :
+                    View.VISIBLE);
         }
     }
 
@@ -708,6 +717,7 @@ public class VideoInviteActivity extends AppCompatActivity {
             public void onDisconnected(Room room, TwilioException e) {
                 localParticipant = null;
                 statusTextView.setText("Disconnected from " + room.getName());
+                reconnectingProgressBar.setVisibility(View.GONE);
                 VideoInviteActivity.this.room = null;
                 enableAudioFocus(false);
                 enableVolumeControl(false);
@@ -747,12 +757,14 @@ public class VideoInviteActivity extends AppCompatActivity {
 
             @Override
             public void onReconnecting(Room room, TwilioException exception) {
-                statusTextView.setText("Reconnecting");
+                statusTextView.setText("Reconnecting to " + room.getName());
+                reconnectingProgressBar.setVisibility(View.VISIBLE);
             }
 
             @Override
             public void onReconnected(Room room) {
-                statusTextView.setText("Reconnected");
+                statusTextView.setText("Connected to " + room.getName());
+                reconnectingProgressBar.setVisibility(View.GONE);
             }
         };
     }

--- a/exampleVideoInvite/src/main/res/layout/content_video.xml
+++ b/exampleVideoInvite/src/main/res/layout/content_video.xml
@@ -25,6 +25,15 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"/>
 
+    <ProgressBar
+        android:id="@+id/reconnecting_progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:indeterminate="true"
+        style="?android:attr/progressBarStyleLarge"
+        android:visibility="gone" />
+
     <TextView
         android:id="@+id/identity_textview"
         android:layout_width="wrap_content"

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -138,7 +138,7 @@ public class VideoActivity extends AppCompatActivity {
     private FloatingActionButton switchCameraActionFab;
     private FloatingActionButton localVideoActionFab;
     private FloatingActionButton muteActionFab;
-    private ProgressBar progressBar;
+    private ProgressBar reconnectingProgressBar;
     private AlertDialog connectDialog;
     private AudioManager audioManager;
     private String remoteParticipantIdentity;
@@ -156,7 +156,7 @@ public class VideoActivity extends AppCompatActivity {
         primaryVideoView = findViewById(R.id.primary_video_view);
         thumbnailVideoView = findViewById(R.id.thumbnail_video_view);
         videoStatusTextView = findViewById(R.id.video_status_textview);
-        progressBar = findViewById(R.id.reconnecting_progress_bar);
+        reconnectingProgressBar = findViewById(R.id.reconnecting_progress_bar);
 
         connectActionFab = findViewById(R.id.connect_action_fab);
         switchCameraActionFab = findViewById(R.id.switch_camera_action_fab);
@@ -293,7 +293,7 @@ public class VideoActivity extends AppCompatActivity {
 
         if (room != null) {
             Room.State state = room.getState();
-            progressBar.setVisibility((state != Room.State.RECONNECTING) ? View.GONE : View.VISIBLE);
+            reconnectingProgressBar.setVisibility((state != Room.State.RECONNECTING) ? View.GONE : View.VISIBLE);
         }
     }
 
@@ -657,13 +657,13 @@ public class VideoActivity extends AppCompatActivity {
             @Override
             public void onReconnecting(@NonNull Room room, @NonNull TwilioException twilioException) {
                 videoStatusTextView.setText("Reconnecting to " + room.getName());
-                progressBar.setVisibility(View.VISIBLE);
+                reconnectingProgressBar.setVisibility(View.VISIBLE);
             }
 
             @Override
             public void onReconnected(@NonNull Room room) {
                 videoStatusTextView.setText("Connected to " + room.getName());
-                progressBar.setVisibility(View.GONE);
+                reconnectingProgressBar.setVisibility(View.GONE);
             }
 
             @Override
@@ -677,7 +677,7 @@ public class VideoActivity extends AppCompatActivity {
             public void onDisconnected(Room room, TwilioException e) {
                 localParticipant = null;
                 videoStatusTextView.setText("Disconnected from " + room.getName());
-                progressBar.setVisibility(View.GONE);
+                reconnectingProgressBar.setVisibility(View.GONE);
                 VideoActivity.this.room = null;
                 // Only reinitialize the UI if disconnect was not called from onDestroy()
                 if (!disconnectedFromOnDestroy) {

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -297,7 +297,7 @@ public class VideoActivity extends AppCompatActivity {
          */
         encodingParameters = newEncodingParameters;
 
-        if(room != null){
+        if (room != null) {
             Room.State state = room.getState();
             progressBar.setVisibility((state != Room.State.RECONNECTING) ? View.GONE : View.VISIBLE);
         }

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -12,7 +12,6 @@ import android.media.AudioManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.provider.Settings;
 import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
@@ -30,8 +29,6 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.google.gson.JsonObject;
-import com.koushikdutta.async.future.FutureCallback;
 import com.koushikdutta.ion.Ion;
 import com.twilio.video.AudioCodec;
 import com.twilio.video.EncodingParameters;
@@ -70,9 +67,6 @@ import com.twilio.video.quickstart.util.CameraCapturerCompat;
 
 import java.util.Collections;
 import java.util.UUID;
-
-import static com.twilio.video.quickstart.R.drawable.ic_phonelink_ring_white_24dp;
-import static com.twilio.video.quickstart.R.drawable.ic_volume_up_white_24dp;
 
 import static com.twilio.video.quickstart.R.drawable.ic_phonelink_ring_white_24dp;
 import static com.twilio.video.quickstart.R.drawable.ic_volume_up_white_24dp;
@@ -162,7 +156,7 @@ public class VideoActivity extends AppCompatActivity {
         primaryVideoView = findViewById(R.id.primary_video_view);
         thumbnailVideoView = findViewById(R.id.thumbnail_video_view);
         videoStatusTextView = findViewById(R.id.video_status_textview);
-        progressBar = findViewById(R.id.progressBar);
+        progressBar = findViewById(R.id.reconnecting_progress_bar);
 
         connectActionFab = findViewById(R.id.connect_action_fab);
         switchCameraActionFab = findViewById(R.id.switch_camera_action_fab);

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -291,9 +291,14 @@ public class VideoActivity extends AppCompatActivity {
          */
         encodingParameters = newEncodingParameters;
 
+        /*
+         * Update reconnecting UI
+         */
         if (room != null) {
-            Room.State state = room.getState();
-            reconnectingProgressBar.setVisibility((state != Room.State.RECONNECTING) ? View.GONE : View.VISIBLE);
+            reconnectingProgressBar.setVisibility((room.getState() != Room.State.RECONNECTING) ?
+                    View.GONE :
+                    View.VISIBLE);
+            videoStatusTextView.setText("Connected to " + room.getName());
         }
     }
 

--- a/quickstart/src/main/res/layout/content_video.xml
+++ b/quickstart/src/main/res/layout/content_video.xml
@@ -25,6 +25,15 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"/>
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:indeterminate="true"
+        style="?android:attr/progressBarStyleLarge"
+        android:visibility="gone" />
+
     <LinearLayout
         android:id="@+id/status"
         android:layout_width="fill_parent"

--- a/quickstart/src/main/res/layout/content_video.xml
+++ b/quickstart/src/main/res/layout/content_video.xml
@@ -26,7 +26,7 @@
         android:layout_gravity="center"/>
 
     <ProgressBar
-        android:id="@+id/progressBar"
+        android:id="@+id/reconnecting_progress_bar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
@@ -116,6 +116,16 @@ class VideoActivity : AppCompatActivity() {
             room.remoteParticipants?.firstOrNull()?.let { addRemoteParticipant(it) }
         }
 
+        override fun onReconnected(room: Room) {
+            videoStatusTextView.text = "Connected to ${room.name}"
+            progressBar.visibility = View.GONE;
+        }
+
+        override fun onReconnecting(room: Room, twilioException: TwilioException) {
+            videoStatusTextView.text = "Reconnecting to ${room.name}"
+            progressBar.visibility = View.VISIBLE;
+        }
+
         override fun onConnectFailure(room: Room, e: TwilioException) {
             videoStatusTextView.text = "Failed to connect"
             configureAudio(false)
@@ -125,6 +135,7 @@ class VideoActivity : AppCompatActivity() {
         override fun onDisconnected(room: Room, e: TwilioException?) {
             localParticipant = null
             videoStatusTextView.text = "Disconnected from ${room.name}"
+            progressBar.visibility = View.GONE;
             this@VideoActivity.room = null
             // Only reinitialize the UI if disconnect was not called from onDestroy()
             if (!disconnectedFromOnDestroy) {
@@ -449,6 +460,11 @@ class VideoActivity : AppCompatActivity() {
          * Update encoding parameters if they have changed.
          */
         localParticipant?.setEncodingParameters(encodingParameters)
+
+        if (room != null) {
+            val state = room!!.state
+            progressBar.visibility = if (state != Room.State.RECONNECTING) View.GONE else View.VISIBLE
+        }
     }
 
     override fun onPause() {

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
@@ -118,12 +118,12 @@ class VideoActivity : AppCompatActivity() {
 
         override fun onReconnected(room: Room) {
             videoStatusTextView.text = "Connected to ${room.name}"
-            progressBar.visibility = View.GONE;
+            reconnecting_progress_bar.visibility = View.GONE;
         }
 
         override fun onReconnecting(room: Room, twilioException: TwilioException) {
             videoStatusTextView.text = "Reconnecting to ${room.name}"
-            progressBar.visibility = View.VISIBLE;
+            reconnecting_progress_bar.visibility = View.VISIBLE;
         }
 
         override fun onConnectFailure(room: Room, e: TwilioException) {
@@ -135,7 +135,7 @@ class VideoActivity : AppCompatActivity() {
         override fun onDisconnected(room: Room, e: TwilioException?) {
             localParticipant = null
             videoStatusTextView.text = "Disconnected from ${room.name}"
-            progressBar.visibility = View.GONE;
+            reconnecting_progress_bar.visibility = View.GONE;
             this@VideoActivity.room = null
             // Only reinitialize the UI if disconnect was not called from onDestroy()
             if (!disconnectedFromOnDestroy) {
@@ -463,7 +463,7 @@ class VideoActivity : AppCompatActivity() {
 
         if (room != null) {
             val state = room!!.state
-            progressBar.visibility = if (state != Room.State.RECONNECTING) View.GONE else View.VISIBLE
+            reconnecting_progress_bar.visibility = if (state != Room.State.RECONNECTING) View.GONE else View.VISIBLE
         }
     }
 

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
@@ -118,12 +118,12 @@ class VideoActivity : AppCompatActivity() {
 
         override fun onReconnected(room: Room) {
             videoStatusTextView.text = "Connected to ${room.name}"
-            reconnecting_progress_bar.visibility = View.GONE;
+            reconnectingProgressBar.visibility = View.GONE;
         }
 
         override fun onReconnecting(room: Room, twilioException: TwilioException) {
             videoStatusTextView.text = "Reconnecting to ${room.name}"
-            reconnecting_progress_bar.visibility = View.VISIBLE;
+            reconnectingProgressBar.visibility = View.VISIBLE;
         }
 
         override fun onConnectFailure(room: Room, e: TwilioException) {
@@ -135,7 +135,7 @@ class VideoActivity : AppCompatActivity() {
         override fun onDisconnected(room: Room, e: TwilioException?) {
             localParticipant = null
             videoStatusTextView.text = "Disconnected from ${room.name}"
-            reconnecting_progress_bar.visibility = View.GONE;
+            reconnectingProgressBar.visibility = View.GONE;
             this@VideoActivity.room = null
             // Only reinitialize the UI if disconnect was not called from onDestroy()
             if (!disconnectedFromOnDestroy) {
@@ -463,7 +463,7 @@ class VideoActivity : AppCompatActivity() {
 
         if (room != null) {
             val state = room!!.state
-            reconnecting_progress_bar.visibility = if (state != Room.State.RECONNECTING) View.GONE else View.VISIBLE
+            reconnectingProgressBar.visibility = if (state != Room.State.RECONNECTING) View.GONE else View.VISIBLE
         }
     }
 

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
@@ -461,9 +461,14 @@ class VideoActivity : AppCompatActivity() {
          */
         localParticipant?.setEncodingParameters(encodingParameters)
 
-        if (room != null) {
-            val state = room!!.state
-            reconnectingProgressBar.visibility = if (state != Room.State.RECONNECTING) View.GONE else View.VISIBLE
+        /*
+         * Update reconnecting UI
+         */
+        room?.let {
+            reconnectingProgressBar.visibility = if (it.state != Room.State.RECONNECTING)
+                View.GONE else
+                View.VISIBLE
+            videoStatusTextView.text = "Connected to ${it.name}"
         }
     }
 

--- a/quickstartKotlin/src/main/res/layout/content_video.xml
+++ b/quickstartKotlin/src/main/res/layout/content_video.xml
@@ -26,6 +26,15 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"/>
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:indeterminate="true"
+        style="?android:attr/progressBarStyleLarge"
+        android:visibility="gone" />
+
     <LinearLayout
         android:id="@+id/status"
         android:layout_width="fill_parent"

--- a/quickstartKotlin/src/main/res/layout/content_video.xml
+++ b/quickstartKotlin/src/main/res/layout/content_video.xml
@@ -27,7 +27,7 @@
         android:layout_gravity="center"/>
 
     <ProgressBar
-        android:id="@+id/progressBar"
+        android:id="@+id/reconnecting_progress_bar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"

--- a/quickstartKotlin/src/main/res/layout/content_video.xml
+++ b/quickstartKotlin/src/main/res/layout/content_video.xml
@@ -27,7 +27,7 @@
         android:layout_gravity="center"/>
 
     <ProgressBar
-        android:id="@+id/reconnecting_progress_bar"
+        android:id="@+id/reconnectingProgressBar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"


### PR DESCRIPTION
### SDK Updates

Improvements

- Added new state `Reconnecting` to `Room.State` and new callbacks `onReconnecting`, `onReconnected` to `Room.Listener`. When the `LocalParticipant` experiences a network interruption in signaling or media, the room will transition to `Reconnecting` and `Room.Listener` will notify the developer of this new state via `onReconnecting`. If the connection is successfully restored, `Room.Listener` will notify the developer via `onReconnected`. However, if the connection could not be reestablished `Room.Listener` will notify the developer via `onDisconnected`.
- Added and updated public API nullability annotations.
- Changed `OpusCodec.NAME` and `IsacCodec.NAME` to lowercase

#### Quickstart Updates

Add Simple reconnecting UI. Screenshot below.

![screenshot_1548194030](https://user-images.githubusercontent.com/1734140/53255765-ee6d3800-368b-11e9-8820-57ccabbb83e4.png)
