### PR TITLE
Cache audio routing 

### DIFF
--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -147,6 +147,7 @@ public class VideoActivity extends AppCompatActivity {
     private boolean previousMicrophoneMute;
     private VideoRenderer localVideoView;
     private boolean disconnectedFromOnDestroy;
+    private boolean isSpeakerPhoneEnabled = true;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -177,7 +178,7 @@ public class VideoActivity extends AppCompatActivity {
          * Needed for setting/abandoning audio focus during call
          */
         audioManager = (AudioManager)getSystemService(Context.AUDIO_SERVICE);
-        audioManager.setSpeakerphoneOn(true);
+        audioManager.setSpeakerphoneOn(isSpeakerPhoneEnabled);
 
         /*
          * Check camera and microphone permissions. Needed in Android M.
@@ -212,9 +213,11 @@ public class VideoActivity extends AppCompatActivity {
                 if (audioManager.isSpeakerphoneOn()) {
                     audioManager.setSpeakerphoneOn(false);
                     item.setIcon(ic_phonelink_ring_white_24dp);
+                    isSpeakerPhoneEnabled = false;
                 } else {
                     audioManager.setSpeakerphoneOn(true);
                     item.setIcon(ic_volume_up_white_24dp);
+                    isSpeakerPhoneEnabled = true;
                 }
                 return true;
             default:
@@ -292,10 +295,9 @@ public class VideoActivity extends AppCompatActivity {
         encodingParameters = newEncodingParameters;
 
         /*
-         * If audio routing switched to headset during a call, route through speaker.
+         * Route audio through cached value.
          */
-         AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
-         audioManager.setSpeakerphoneOn(true);
+         audioManager.setSpeakerphoneOn(isSpeakerPhoneEnabled);
 
         /*
          * Update reconnecting UI
@@ -327,6 +329,8 @@ public class VideoActivity extends AppCompatActivity {
             localVideoTrack.release();
             localVideoTrack = null;
         }
+        // Cache speaker phone state
+        isSpeakerPhoneEnabled = audioManager.isSpeakerphoneOn();
         super.onPause();
     }
 

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -293,6 +293,12 @@ public class VideoActivity extends AppCompatActivity {
          * Update encoding parameters
          */
         encodingParameters = newEncodingParameters;
+
+        /*
+         * If audio routing switched to headset during a call, route through speaker.
+         */
+         AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+         audioManager.setSpeakerphoneOn(true);
     }
 
     @Override

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -329,8 +329,6 @@ public class VideoActivity extends AppCompatActivity {
             localVideoTrack.release();
             localVideoTrack = null;
         }
-        // Cache speaker phone state
-        isSpeakerPhoneEnabled = audioManager.isSpeakerphoneOn();
         super.onPause();
     }
 


### PR DESCRIPTION
### Description
#383 found that when receiving and answering a phone call audio would be routed to the handset after hanging up. This PR addresses #383 by forcing audio routing through the speaker. 

### Breakdown
- Added `audioManager.setSpeakerphoneOn(true);` to `onResume`. 

### Validation
- Tested locally and could no longer reproduce the issue.  