### PR TITLE
Add speakerphone routing work around for Kotlin

### DIFF
--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
@@ -380,6 +380,7 @@ class VideoActivity : AppCompatActivity() {
     private var previousMicrophoneMute = false
     private lateinit var localVideoView: VideoRenderer
     private var disconnectedFromOnDestroy = false
+    private var isSpeakerPhoneEnabled = true
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -462,6 +463,11 @@ class VideoActivity : AppCompatActivity() {
         localParticipant?.setEncodingParameters(encodingParameters)
 
         /*
+         * Route audio through cached value.
+         */
+        audioManager.isSpeakerphoneOn = isSpeakerPhoneEnabled
+
+        /*
          * Update reconnecting UI
          */
         room?.let {
@@ -520,9 +526,11 @@ class VideoActivity : AppCompatActivity() {
             R.id.speaker_menu_item -> if (audioManager.isSpeakerphoneOn) {
                 audioManager.isSpeakerphoneOn = false
                 item.setIcon(R.drawable.ic_phonelink_ring_white_24dp)
+                isSpeakerPhoneEnabled = false
             } else {
                 audioManager.isSpeakerphoneOn = true
                 item.setIcon(R.drawable.ic_volume_up_white_24dp)
+                isSpeakerPhoneEnabled = true
             }
         }
         return true


### PR DESCRIPTION
### Description
#383 found that when receiving and answering a phone call audio would be routed to the handset after hanging up. This PR addresses #383 by forcing audio routing through the speaker. 

### Breakdown
- `isSpeakerPhoneEnabled` is used to cache the speaker phone audio route setting
- `audioManager.isSpeakerphoneOn = isSpeakerPhoneEnabled` is applied in `onResume`.

### Validation
- Tested locally and could no longer reproduce the issue.  