### PR TITLE
Video Android 4.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '4.0.0'
+            'videoAndroid': '4.0.1'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->


### PR DESCRIPTION
#### 4.0.1

Bug Fixes

- `Room.getStats()` will raise a callback to the provided `StatsObserver` if called while `Room.getState() == Room.State.RECONNECTING`.
- Fixed a crash related to stats gathering which could occur when insights reporting is enabled.
- Fixed a crash related to media state summarization which could occur when disconnecting from a Room.
- Fixed a crash related to stats gathering which could occur in the media monitor component.

Known issues

- Network handoff, and subsequent connection renegotiation is not supported for IPv6 networks [#72](https://github.com/twilio/video-quickstart-android/issues/72)
- Participant disconnect event can take up to 120 seconds to occur [#80](https://github.com/twilio/video-quickstart-android/issues/80) [#73](https://github.com/twilio/video-quickstart-android/issues/73)
- The SDK is not side-by-side compatible with other WebRTC based libraries [#340](https://github.com/twilio/video-quickstart-android/issues/340)
- Codec preferences do not function correctly in a hybrid codec Group Room with the following
codecs:
    - ISAC
    - PCMA
    - G722
    - VP9
- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants.