### PR TITLE
Gradle, Android Gradle Plugin and Kotlin version bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.61'
+    ext.kotlin_version = '1.3.0'
     ext.versions = [
             'java': JavaVersion.VERSION_1_8,
-            'androidGradlePlugin': '3.2.1',
+            'androidGradlePlugin': '3.3.2',
             'googleServices': '3.2.1',
             'compileSdk': 28,
             'buildTools': '28.0.3',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Oct 19 11:22:48 CDT 2018
+#Wed Apr 03 15:26:35 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
<!-- Describe your Pull Request -->

I've updated the versions of Gradle, Android Gradle Plugin and Kotlin. Therefore, the project can be opened with the current stable Android Studio release (3.2.2 as of today) without any warning.

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
