### PR TITLE
Update to Video Android 4.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '4.1.1'
+            'videoAndroid': '4.1.2'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->


### PR DESCRIPTION
#### 4.1.2

Bug Fixes

- Fixed stuck aspect ratio when switching orientations with `ScreenCapturer`.
- Fixed a bug where media reconnection might fail when the loopback interface is mistakenly chosen as a preferred network interface.

Known issues

- Network handoff, and subsequent connection renegotiation is not supported for IPv6 networks [#72](https://github.com/twilio/video-quickstart-android/issues/72)
- Participant disconnect event can take up to 120 seconds to occur [#80](https://github.com/twilio/video-quickstart-android/issues/80) [#73](https://github.com/twilio/video-quickstart-android/issues/73)
- The SDK is not side-by-side compatible with other WebRTC based libraries [#340](https://github.com/twilio/video-quickstart-android/issues/340)
- Codec preferences do not function correctly in a hybrid codec Group Room with the following
codecs:
    - ISAC
    - PCMA
    - G722
    - VP9
- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. As a result, tracks published after a `Room.State.RECONNECTED` event might not be subscribed to by a `RemoteParticipant`.

Size Report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| universal       | 22.5MB          |
| armeabi-v7a     | 5MB             |
| arm64-v8a       | 5.8MB           |
| x86             | 6.1MB           |
| x86_64          | 6.2MB           |
