### PR TITLE
Making Audio Focus Handling Complaint with Android SDK 28

### DIFF
--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -145,6 +145,7 @@ public class VideoActivity extends AppCompatActivity {
 
     private int previousAudioMode;
     private boolean previousMicrophoneMute;
+    private AudioFocusRequest previousFocusRequest;
     private VideoRenderer localVideoView;
     private boolean disconnectedFromOnDestroy;
     private boolean isSpeakerPhoneEnabled = true;
@@ -1105,7 +1106,7 @@ public class VideoActivity extends AppCompatActivity {
             audioManager.setMicrophoneMute(false);
         } else {
             audioManager.setMode(previousAudioMode);
-            audioManager.abandonAudioFocus(null);
+            abandonAudioFocus();
             audioManager.setMicrophoneMute(previousMicrophoneMute);
         }
     }
@@ -1116,17 +1117,28 @@ public class VideoActivity extends AppCompatActivity {
                     .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
                     .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
                     .build();
-            AudioFocusRequest focusRequest =
+            previousFocusRequest =
                     new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
                             .setAudioAttributes(playbackAttributes)
                             .setAcceptsDelayedFocusGain(true)
                             .setOnAudioFocusChangeListener(
                                     i -> { })
                             .build();
-            audioManager.requestAudioFocus(focusRequest);
+            audioManager.requestAudioFocus(previousFocusRequest);
         } else {
             audioManager.requestAudioFocus(null, AudioManager.STREAM_VOICE_CALL,
                     AudioManager.AUDIOFOCUS_GAIN_TRANSIENT);
+        }
+    }
+
+    private void abandonAudioFocus() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            if (previousFocusRequest != null) {
+                audioManager.abandonAudioFocusRequest(previousFocusRequest);
+                previousFocusRequest = null;
+}
+        } else {
+            audioManager.abandonAudioFocus(null);
         }
     }
 }

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -31,12 +31,16 @@ import android.widget.Toast;
 
 import com.koushikdutta.ion.Ion;
 import com.twilio.video.AudioCodec;
-import com.twilio.video.EncodingParameters;
 import com.twilio.video.CameraCapturer;
+import com.twilio.video.CameraCapturer.CameraSource;
+import com.twilio.video.ConnectOptions;
+import com.twilio.video.EncodingParameters;
 import com.twilio.video.G722Codec;
 import com.twilio.video.H264Codec;
 import com.twilio.video.IsacCodec;
+import com.twilio.video.LocalAudioTrack;
 import com.twilio.video.LocalParticipant;
+import com.twilio.video.LocalVideoTrack;
 import com.twilio.video.OpusCodec;
 import com.twilio.video.PcmaCodec;
 import com.twilio.video.PcmuCodec;
@@ -47,22 +51,18 @@ import com.twilio.video.RemoteDataTrackPublication;
 import com.twilio.video.RemoteParticipant;
 import com.twilio.video.RemoteVideoTrack;
 import com.twilio.video.RemoteVideoTrackPublication;
+import com.twilio.video.Room;
+import com.twilio.video.TwilioException;
 import com.twilio.video.Video;
 import com.twilio.video.VideoCodec;
 import com.twilio.video.VideoRenderer;
-import com.twilio.video.TwilioException;
+import com.twilio.video.VideoTrack;
+import com.twilio.video.VideoView;
 import com.twilio.video.Vp8Codec;
 import com.twilio.video.Vp9Codec;
 import com.twilio.video.quickstart.BuildConfig;
 import com.twilio.video.quickstart.R;
 import com.twilio.video.quickstart.dialog.Dialog;
-import com.twilio.video.CameraCapturer.CameraSource;
-import com.twilio.video.ConnectOptions;
-import com.twilio.video.LocalAudioTrack;
-import com.twilio.video.LocalVideoTrack;
-import com.twilio.video.Room;
-import com.twilio.video.VideoTrack;
-import com.twilio.video.VideoView;
 import com.twilio.video.quickstart.util.CameraCapturerCompat;
 
 import java.util.Collections;
@@ -178,7 +178,7 @@ public class VideoActivity extends AppCompatActivity {
         /*
          * Needed for setting/abandoning audio focus during call
          */
-        audioManager = (AudioManager)getSystemService(Context.AUDIO_SERVICE);
+        audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
         audioManager.setSpeakerphoneOn(isSpeakerPhoneEnabled);
 
         /*
@@ -210,7 +210,7 @@ public class VideoActivity extends AppCompatActivity {
             case R.id.menu_settings:
                 startActivity(new Intent(this, SettingsActivity.class));
                 return true;
-             case R.id.speaker_menu_item:
+            case R.id.speaker_menu_item:
                 if (audioManager.isSpeakerphoneOn()) {
                     audioManager.setSpeakerphoneOn(false);
                     item.setIcon(ic_phonelink_ring_white_24dp);
@@ -249,7 +249,7 @@ public class VideoActivity extends AppCompatActivity {
     }
 
     @Override
-    protected  void onResume() {
+    protected void onResume() {
         super.onResume();
 
         /*
@@ -298,7 +298,7 @@ public class VideoActivity extends AppCompatActivity {
         /*
          * Route audio through cached value.
          */
-         audioManager.setSpeakerphoneOn(isSpeakerPhoneEnabled);
+        audioManager.setSpeakerphoneOn(isSpeakerPhoneEnabled);
 
         /*
          * Update reconnecting UI
@@ -360,14 +360,14 @@ public class VideoActivity extends AppCompatActivity {
         super.onDestroy();
     }
 
-    private boolean checkPermissionForCameraAndMicrophone(){
+    private boolean checkPermissionForCameraAndMicrophone() {
         int resultCamera = ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA);
         int resultMic = ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO);
         return resultCamera == PackageManager.PERMISSION_GRANTED &&
-               resultMic == PackageManager.PERMISSION_GRANTED;
+                resultMic == PackageManager.PERMISSION_GRANTED;
     }
 
-    private void requestPermissionForCameraAndMicrophone(){
+    private void requestPermissionForCameraAndMicrophone() {
         if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.CAMERA) ||
                 ActivityCompat.shouldShowRequestPermissionRationale(this,
                         Manifest.permission.RECORD_AUDIO)) {
@@ -564,7 +564,7 @@ public class VideoActivity extends AppCompatActivity {
             return;
         }
         remoteParticipantIdentity = remoteParticipant.getIdentity();
-        videoStatusTextView.setText("RemoteParticipant "+ remoteParticipantIdentity + " joined");
+        videoStatusTextView.setText("RemoteParticipant " + remoteParticipantIdentity + " joined");
 
         /*
          * Add remote participant renderer
@@ -1122,7 +1122,8 @@ public class VideoActivity extends AppCompatActivity {
                             .setAudioAttributes(playbackAttributes)
                             .setAcceptsDelayedFocusGain(true)
                             .setOnAudioFocusChangeListener(
-                                    i -> { })
+                                    i -> {
+                                    })
                             .build();
             audioManager.requestAudioFocus(previousFocusRequest);
         } else {
@@ -1136,7 +1137,7 @@ public class VideoActivity extends AppCompatActivity {
             if (previousFocusRequest != null) {
                 audioManager.abandonAudioFocusRequest(previousFocusRequest);
                 previousFocusRequest = null;
-}
+            }
         } else {
             audioManager.abandonAudioFocus(null);
         }

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
@@ -10,13 +10,13 @@ import android.media.AudioAttributes
 import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.os.Build
-import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
 import android.preference.PreferenceManager
 import android.support.design.widget.Snackbar
 import android.support.v4.app.ActivityCompat
 import android.support.v4.content.ContextCompat
 import android.support.v7.app.AlertDialog
+import android.support.v7.app.AppCompatActivity
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
@@ -295,8 +295,8 @@ class VideoActivity : AppCompatActivity() {
         }
 
         override fun onDataTrackSubscriptionFailed(remoteParticipant: RemoteParticipant,
-                                                    remoteDataTrackPublication: RemoteDataTrackPublication,
-                                                    twilioException: TwilioException) {
+                                                   remoteDataTrackPublication: RemoteDataTrackPublication,
+                                                   twilioException: TwilioException) {
             Log.i(TAG, "onDataTrackSubscriptionFailed: " +
                     "[RemoteParticipant: identity=${remoteParticipant.identity}], " +
                     "[RemoteDataTrackPublication: sid=${remoteDataTrackPublication.trackSid}, " +


### PR DESCRIPTION
Using `abandonAudioFocusRequest()` to abandon the audio focus in SDK 28 and above. 
Reference: [https://developer.android.com/guide/topics/media-apps/audio-focus#audio-focus-8-0](https://developer.android.com/guide/topics/media-apps/audio-focus#audio-focus-8-0)

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
