### PR TITLE
Video Android 4.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '4.1.2'
+            'videoAndroid': '4.2.0'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->


### PR DESCRIPTION
### 4.2.0
 Improvements

 - Added field `enableAutomaticSubscription` to `ConnectOptions`. `enableAutomaticSubscription` toggles automatic track subscription. If set to `false`, the `LocalParticipant` will receive notifications of track publish events, but will not automatically subscribe to them. If
set to `true`, the `LocalParticipant` will automatically subscribe to tracks as they are published. If unset, the default is `true`. Note: This feature is only available for Group Rooms. Toggling the flag in a P2P room does not modify subscription behavior.

Known issues

- Network handoff, and subsequent connection renegotiation is not supported for IPv6 networks [#72](https://github.com/twilio/video-quickstart-android/issues/72)
- Participant disconnect event can take up to 120 seconds to occur [#80](https://github.com/twilio/video-quickstart-android/issues/80) [#73](https://github.com/twilio/video-quickstart-android/issues/73)
- The SDK is not side-by-side compatible with other WebRTC based libraries [#340](https://github.com/twilio/video-quickstart-android/issues/340)
- Codec preferences do not function correctly in a hybrid codec Group Room with the following
codecs:
    - ISAC
    - PCMA
    - G722
    - VP9
- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. As a result, tracks published after a `Room.State.RECONNECTED` event might not be subscribed to by a `RemoteParticipant`.