### PR TITLE
Add dominant speaker to multi party example

### DIFF
--- a/exampleMultipartyVideo/src/main/java/com/twilio/examplemultipartyvideo/MultiPartyActivity.java
+++ b/exampleMultipartyVideo/src/main/java/com/twilio/examplemultipartyvideo/MultiPartyActivity.java
@@ -12,6 +12,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.ActivityCompat;
@@ -20,8 +21,11 @@ import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.EditText;
+import android.widget.ImageView;
 import android.widget.ProgressBar;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -134,6 +138,7 @@ public class MultiPartyActivity extends AppCompatActivity {
     private Stack<VideoTextureView> availableVideoTextureViews = new Stack<>();
     private Map<Participant, VideoTextureView> videoViewMap = new HashMap<>();
     private VideoTextureView localVideoTextureView;
+    private ImageView dominantSpeakerImg;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -365,7 +370,7 @@ public class MultiPartyActivity extends AppCompatActivity {
 
     private void connectToRoom(String roomName) {
         configureAudio(true);
-        ConnectOptions.Builder connectOptionsBuilder = new ConnectOptions.Builder(accessToken)
+        ConnectOptions.Builder connectOptionsBuilder = new ConnectOptions.Builder(accessToken).enableDominantSpeaker(true)
                 .roomName(roomName);
 
         /*
@@ -410,6 +415,8 @@ public class MultiPartyActivity extends AppCompatActivity {
         localVideoActionFab.setOnClickListener(localVideoClickListener());
         muteActionFab.show();
         muteActionFab.setOnClickListener(muteClickListener());
+        dominantSpeakerImg = new ImageView(this);
+        dominantSpeakerImg.setImageResource(android.R.drawable.ic_lock_silent_mode_off);
     }
 
     /*
@@ -584,6 +591,23 @@ public class MultiPartyActivity extends AppCompatActivity {
                     configureAudio(false);
                     initializeVideoTextureViews();
                     intializeUI();
+                }
+            }
+
+            @Override
+            public void onDominantSpeakerChanged(@NonNull Room room, @Nullable RemoteParticipant remoteParticipant) {
+                if (dominantSpeakerImg.getParent() != null) {
+                    ((ViewGroup) dominantSpeakerImg.getParent()).removeView(dominantSpeakerImg);
+                }
+                if (remoteParticipant != null) {
+                    VideoTextureView videoTextureView = videoViewMap.get(remoteParticipant);
+                    ViewGroup parent = (ViewGroup) videoTextureView.getParent();
+
+                    RelativeLayout.LayoutParams layoutParams = new RelativeLayout.LayoutParams(120, 120);
+                    layoutParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
+                    dominantSpeakerImg.setLayoutParams(layoutParams);
+
+                    parent.addView(dominantSpeakerImg);
                 }
             }
 

--- a/exampleMultipartyVideo/src/main/res/layout/content_video.xml
+++ b/exampleMultipartyVideo/src/main/res/layout/content_video.xml
@@ -14,18 +14,27 @@
         android:layout_weight="0.5"
         android:orientation="horizontal">
 
+        <RelativeLayout
+            android:layout_width="wrap_content"
+            android:layout_weight="0.5"
+            android:layout_height="wrap_content">
+
         <com.twilio.video.VideoTextureView
             android:id="@+id/local_participant_video_texture_view"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_weight="0.5" />
+            android:layout_height="match_parent"/>
 
+        </RelativeLayout>
+        <RelativeLayout
+            android:layout_width="wrap_content"
+            android:layout_weight="0.5"
+            android:layout_height="wrap_content">
         <com.twilio.video.VideoTextureView
             android:id="@+id/remote_participant_video_texture_view1"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_weight="0.5"
             android:visibility="gone" />
+        </RelativeLayout>
     </LinearLayout>
 
     <ProgressBar
@@ -42,19 +51,29 @@
         android:layout_weight="0.5"
         android:orientation="horizontal">
 
+        <RelativeLayout
+            android:layout_width="wrap_content"
+            android:layout_weight="0.5"
+            android:layout_height="wrap_content">
+
         <com.twilio.video.VideoTextureView
             android:id="@+id/remote_participant_video_texture_view2"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_weight="0.5"
             android:visibility="gone" />
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:layout_width="wrap_content"
+            android:layout_weight="0.5"
+            android:layout_height="wrap_content">
 
         <com.twilio.video.VideoTextureView
             android:id="@+id/remote_participant_video_texture_view3"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_weight="0.5"
             android:visibility="gone" />
+        </RelativeLayout>
     </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
This PR adds dominant speaker detection to the multi party quick start example. 

<img width="263" alt="Screen Shot 2019-08-05 at 4 25 03 PM" src="https://user-images.githubusercontent.com/8648217/62501117-182f9c80-b79e-11e9-9d9b-132c06a9f807.png">
<img width="268" alt="Screen Shot 2019-08-05 at 4 25 18 PM" src="https://user-images.githubusercontent.com/8648217/62501118-18c83300-b79e-11e9-955b-62fc0df56731.png">
