### PR TITLE
GSDK-1987: Provide workaround for S10 camera crash

### DIFF
--- a/quickstart/src/main/java/com/twilio/video/quickstart/util/CameraCapturerCompat.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/util/CameraCapturerCompat.java
@@ -7,6 +7,7 @@ import android.hardware.camera2.CameraCharacteristics;
 import android.hardware.camera2.CameraManager;
 import android.hardware.camera2.params.StreamConfigurationMap;
 import android.os.Build;
+import android.support.annotation.RequiresApi;
 import android.util.Log;
 import android.util.Pair;
 
@@ -26,6 +27,7 @@ public class CameraCapturerCompat {
     private Camera2Capturer camera2Capturer;
     private Pair<CameraCapturer.CameraSource, String> frontCameraPair;
     private Pair<CameraCapturer.CameraSource, String> backCameraPair;
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     private CameraManager cameraManager;
     private final Camera2Capturer.Listener camera2Listener = new Camera2Capturer.Listener() {
         @Override
@@ -98,6 +100,7 @@ public class CameraCapturerCompat {
         return camera1Capturer != null;
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     private void setCameraPairs(Context context) {
         Camera2Enumerator camera2Enumerator = new Camera2Enumerator(context);
         for (String cameraId : camera2Enumerator.getDeviceNames()) {
@@ -138,23 +141,19 @@ public class CameraCapturerCompat {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     private boolean isPrivateImageFormatSupportedForCameraId(String cameraId) {
         boolean isPrivateImageFormatSupported;
-        if (isLollipopApiSupported()) {
-            CameraCharacteristics cameraCharacteristics = null;
-            try {
-                cameraCharacteristics = cameraManager.getCameraCharacteristics(cameraId);
-            } catch (CameraAccessException e) {
-                e.printStackTrace();
-            }
-            final StreamConfigurationMap streamMap =
-                    cameraCharacteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
-            isPrivateImageFormatSupported = streamMap.isOutputSupportedFor(ImageFormat.PRIVATE);
+        CameraCharacteristics cameraCharacteristics;
+        try {
+            cameraCharacteristics = cameraManager.getCameraCharacteristics(cameraId);
+        } catch (CameraAccessException e) {
+            e.printStackTrace();
+            return false;
         }
-        else{
-            isPrivateImageFormatSupported = true;
-        }
+        final StreamConfigurationMap streamMap =
+                cameraCharacteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
+        isPrivateImageFormatSupported = streamMap.isOutputSupportedFor(ImageFormat.PRIVATE);
         return isPrivateImageFormatSupported;
     }
-
 }

--- a/quickstart/src/main/java/com/twilio/video/quickstart/util/CameraCapturerCompat.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/util/CameraCapturerCompat.java
@@ -139,7 +139,7 @@ public class CameraCapturerCompat {
     }
 
     private boolean isPrivateImageFormatSupportedForCameraId(String cameraId) {
-        boolean isPrivateSupported = true;
+        boolean isPrivateImageFormatSupported;
         if (isLollipopApiSupported()) {
             CameraCharacteristics cameraCharacteristics = null;
             try {
@@ -149,9 +149,12 @@ public class CameraCapturerCompat {
             }
             final StreamConfigurationMap streamMap =
                     cameraCharacteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
-            isPrivateSupported = streamMap.isOutputSupportedFor(ImageFormat.PRIVATE);
+            isPrivateImageFormatSupported = streamMap.isOutputSupportedFor(ImageFormat.PRIVATE);
         }
-        return isPrivateSupported;
+        else{
+            isPrivateImageFormatSupported = true;
+        }
+        return isPrivateImageFormatSupported;
     }
 
 }

--- a/quickstart/src/main/java/com/twilio/video/quickstart/util/CameraCapturerCompat.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/util/CameraCapturerCompat.java
@@ -102,9 +102,11 @@ public class CameraCapturerCompat {
         Camera2Enumerator camera2Enumerator = new Camera2Enumerator(context);
         for (String cameraId : camera2Enumerator.getDeviceNames()) {
             if (!isPrivateImageFormatSupportedForCameraId(cameraId)) {
-                // This is a temporary work around for a crash on the Samsung S10 that occurs due to the presence of many different cameras.
-                // A long term fix is currently in development.
-                // https://github.com/twilio/video-quickstart-android/issues/431
+                /*
+                 * This is a temporary work around for a RuntimeException that occurs on devices which contain cameras
+                 * that do not support ImageFormat.PRIVATE output formats. A long term fix is currently in development.
+                 * https://github.com/twilio/video-quickstart-android/issues/431
+                 */
                 continue;
             }
             if (camera2Enumerator.isFrontFacing(cameraId)) {


### PR DESCRIPTION
This PR introduces a fix for the crash experienced on the Samsung S10 as described in this [issue](https://github.com/twilio/video-quickstart-android/issues/431). This is a temporary work around and a long term solution is currently in development. 