### PR TITLE
Update for 5.0.0-beta3 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ aliases:
   - &build-defaults
     working_directory: *workspace
     docker:
-      - image: circleci/android:api-28-node8-alpha
+      - image: circleci/android:api-28-node
     environment:
       - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.0'
+    ext.kotlin_version = '1.3.50'
     ext.versions = [
             'java': JavaVersion.VERSION_1_8,
-            'androidGradlePlugin': '3.3.2',
+            'androidGradlePlugin': '3.5.0',
             'googleServices': '3.2.1',
             'compileSdk': 28,
             'buildTools': '28.0.3',
@@ -15,7 +15,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '5.0.0-beta2'
+            'videoAndroid': '5.0.0-beta3'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->

--- a/exampleAdvancedCameraCapturer/build.gradle
+++ b/exampleAdvancedCameraCapturer/build.gradle
@@ -1,4 +1,3 @@
-apply from: "$rootProject.projectDir/gradle.properties"
 apply plugin: 'com.android.application'
 
 android {

--- a/exampleCustomVideoCapturer/build.gradle
+++ b/exampleCustomVideoCapturer/build.gradle
@@ -1,4 +1,3 @@
-apply from: "$rootProject.projectDir/gradle.properties"
 apply plugin: 'com.android.application'
 
 android {

--- a/exampleCustomVideoRenderer/build.gradle
+++ b/exampleCustomVideoRenderer/build.gradle
@@ -1,4 +1,3 @@
-apply from: "$rootProject.projectDir/gradle.properties"
 apply plugin: 'com.android.application'
 
 android {

--- a/exampleMultipartyVideo/src/main/java/com/twilio/examplemultipartyvideo/MultiPartyActivity.java
+++ b/exampleMultipartyVideo/src/main/java/com/twilio/examplemultipartyvideo/MultiPartyActivity.java
@@ -102,10 +102,6 @@ public class MultiPartyActivity extends AppCompatActivity {
     private VideoCodec videoCodec;
 
     /*
-     * Encoding parameters represent the sender side bandwidth constraints.
-     */
-    private EncodingParameters encodingParameters;
-    /*
      * Android shared preferences used for settings
      */
     private SharedPreferences preferences;
@@ -388,11 +384,6 @@ public class MultiPartyActivity extends AppCompatActivity {
          */
         connectOptionsBuilder.preferAudioCodecs(Collections.singletonList(audioCodec));
         connectOptionsBuilder.preferVideoCodecs(Collections.singletonList(videoCodec));
-
-        /*
-         * Set the sender side encoding parameters.
-         */
-        connectOptionsBuilder.encodingParameters(encodingParameters);
 
         room = Video.connect(this, connectOptionsBuilder.build(), roomListener());
         setDisconnectAction();

--- a/exampleScreenCapturer/build.gradle
+++ b/exampleScreenCapturer/build.gradle
@@ -1,4 +1,3 @@
-apply from: "$rootProject.projectDir/gradle.properties"
 apply plugin: 'com.android.application'
 
 android {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-
+android.enableDexingArtifactTransform.desugaring=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 03 15:26:35 CEST 2019
+#Tue Sep 17 10:02:58 CDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -1,4 +1,3 @@
-apply from: "$rootProject.projectDir/gradle.properties"
 apply plugin: 'com.android.application'
 
 android {


### PR DESCRIPTION
## Dominant Speaker Detection API

The Dominant Speaker Detection API sends events to your application every time the dominant speaker changes. You can use those events to improve the end user's experience by, for example, highlighting which participant is currently talking.

The Dominant Speaker Detection API is only available for Group Rooms.  To enable dominant speaker detection, set the `ConnectOptions.dominantSpeakerEnabled` property to `true`. Use `Room.getDominantSpeaker()` to determine the current dominant speaker. Implement `Room.Listener.onDominantSpeakerChanged()` method to receive callbacks when the dominant speaker changes.

For more information, refer to the [API docs](https://twilio.github.io/twilio-video-android/docs/5.0.0-beta3/) and to the [dominant speaker tutorial](https://www.twilio.com/docs/video/detecting-dominant-speaker)

```.java
 ConnectOptions connectOptions =
                new ConnectOptions.Builder(token)
                        .roomName(roomName)
                        .enableDominantSpeaker(true)
                        .build();
Room room = Video.connect(context, connectOptions, roomListener);

@Override
void onDominantSpeakerChanged(
                @NonNull Room room, @Nullable RemoteParticipant remoteParticipant) {
                // Handle dominant speaker change
        }

```

API Changes

- Introduced `TwilioException.SIGNALING_DNS_RESOLUTION_ERROR_EXCEPTION`, which is now raised instead of `TwilioException.SIGNALING_CONNECTION_ERROR_EXCEPTION` in the following scenarios:
  - The device has misconfigured DNS Server(s) on its active network interface.
  - The region provided in `ConnectOptions` was invalid.
  - The device lost its Internet connection before the query could complete.


Enhancements

- Reduced connection times by removing a round trip when:
  - Reconnecting after a signaling connection failure
  - Connecting with `ConnectOptions.iceOptions`, and overridden Servers
  - Connecting with default ICE servers (us1 only)

Bug Fixes

- Fixed crash that occurred when rapidly connecting and disconnecting from a room.
- Fixed updating `CameraCapturer.State` when error occurs.
- Setting `ConnectOptions.region` to an empty or null value results in the default region being
used.
- Fixed a bug where native memory was leaked after disconnecting from a `Room`.
- Fixed a bug where network monitoring would continue on closed connections in a Peer-to-Peer Room.