### PR TITLE
Use Video Android SDK 5.0.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The following snippet shows an example `build.gradle` with APK splits enabled.
     }
     
     dependencies {
-        compile "com.twilio:video-android:5.0.0"
+        compile "com.twilio:video-android:5.0.1"
     }
 
 The adoption of APK splits requires developers to submit multiple APKs to the Play Store. Refer to [Google’s documentation](https://developer.android.com/google/play/publishing/multiple-apks.html) for how to support this in your application.

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '5.0.0'
+            'videoAndroid': '5.0.1'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->


### PR DESCRIPTION
### 5.0.1  (November 6th, 2019)

* Programmable Video Android SDK 5.0.1 [[bintray]](https://bintray.com/twilio/releases/video-android/5.0.1), [[docs]](https://twilio.github.io/twilio-video-android/docs/5.0.1/)

#### Bug Fixes

- Fixed a deadlock that could occur when destroying a `Room` without waiting for `Room.Listener.onDisconnected(...)` to arrive.
- Fixed a crash which could occur when disconnecting from a  `Room` with dominant speaker enabled.

#### Known issues

- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. As a result, tracks published after a `Room.State.RECONNECTED` event might not be subscribed to by a `RemoteParticipant`.


Size Report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| universal       | 22.9MB          |
| armeabi-v7a     | 5MB             |
| arm64-v8a       | 5.9MB           |
| x86             | 6.3MB           |
| x86_64          | 6.4MB           |

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
