### PR TITLE
Update to 5.1.0 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.7',
-            'videoAndroid': '5.0.1'
+            'videoAndroid': '5.1.0'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->

--- a/exampleCustomVideoRenderer/src/main/java/com/twilio/video/examples/customrenderer/SnapshotVideoRenderer.java
+++ b/exampleCustomVideoRenderer/src/main/java/com/twilio/video/examples/customrenderer/SnapshotVideoRenderer.java
@@ -12,8 +12,8 @@ import android.widget.ImageView;
 import com.twilio.video.I420Frame;
 import com.twilio.video.VideoRenderer;
 
-import org.webrtc.RendererCommon;
-import org.webrtc.YuvConverter;
+import tvi.webrtc.RendererCommon;
+import tvi.webrtc.YuvConverter;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/SettingsActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/SettingsActivity.java
@@ -8,7 +8,6 @@ import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.preference.EditTextPreference;
 import android.support.v7.preference.ListPreference;
-import android.support.v7.preference.Preference;
 import android.support.v7.preference.PreferenceFragmentCompat;
 import android.view.MenuItem;
 
@@ -24,8 +23,8 @@ import com.twilio.video.Vp8Codec;
 import com.twilio.video.Vp9Codec;
 import com.twilio.video.quickstart.R;
 
-import org.webrtc.MediaCodecVideoDecoder;
-import org.webrtc.MediaCodecVideoEncoder;
+import tvi.webrtc.MediaCodecVideoDecoder;
+import tvi.webrtc.MediaCodecVideoEncoder;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/SettingsActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/SettingsActivity.kt
@@ -10,9 +10,8 @@ import android.support.v7.preference.Preference
 import android.support.v7.preference.PreferenceFragmentCompat
 import android.view.MenuItem
 import com.twilio.video.*
-import org.webrtc.MediaCodecVideoDecoder
-import org.webrtc.MediaCodecVideoEncoder
-import java.util.*
+import tvi.webrtc.MediaCodecVideoDecoder
+import tvi.webrtc.MediaCodecVideoEncoder
 
 class SettingsActivity : AppCompatActivity() {
     companion object {


### PR DESCRIPTION
### 5.1.0 (November 22nd, 2019)

* Programmable Video Android SDK 5.1.0 [[bintray]](https://bintray.com/twilio/releases/video-android/5.1.0), [[docs]](https://twilio.github.io/twilio-video-android/docs/5.1.0/)

Improvements

- The SDK can now be compiled alongside another WebRTC based dependency. Please perform the
following steps to properly upgrade to `5.1.0`
    - Modify the classpath of any java files used from `org.webrtc.*` to `tvi.webrtc.*`. Calling
    APIs to any class in `org.webrtc.*` will have no effect within the Video SDK.
    - Perform the following modifications to your proguard file when compiling the Video SDK for a
    release build with obfuscation.
      - Change `-keep class org.webrtc.** { *; }` to `-keep class tvi.webrtc.** { *; }`
      - Change `-dontwarn org.webrtc.**` to `-dontwarn tvi.webrtc.**`

Known issues

- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. As a result, tracks published after a `Room.State.RECONNECTED` event might not be subscribed to by a `RemoteParticipant`.

Size Report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| universal       | 22.9MB          |
| armeabi-v7a     | 5MB             |
| arm64-v8a       | 5.9MB           |
| x86             | 6.3MB           |
| x86_64          | 6.4MB           |