### PR TITLE
GSDK-1981 : Fix  Screen Capturer crash targeting Android Q

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
             'compileSdk': 29,
             'buildTools': '28.0.3',
             'minSdk': 16,
-            'targetSdk': 28,
+            'targetSdk': 29,
             'supportLibrary': '26.1.0',
             'constraintLayout': '1.1.3',
             'firebase': '10.0.1',

--- a/exampleScreenCapturer/src/main/AndroidManifest.xml
+++ b/exampleScreenCapturer/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.twilio.video.examples.screencapturer">
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+
     <application android:allowBackup="false"
         android:label="@string/app_name"
         android:supportsRtl="true"
@@ -16,6 +18,11 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <service
+            android:enabled="true"
+            android:name=".ScreenCapturerService"
+            android:foregroundServiceType="mediaProjection" >
+        </service>
     </application>
 
 </manifest>

--- a/exampleScreenCapturer/src/main/AndroidManifest.xml
+++ b/exampleScreenCapturer/src/main/AndroidManifest.xml
@@ -21,7 +21,8 @@
         <service
             android:enabled="true"
             android:name=".ScreenCapturerService"
-            android:foregroundServiceType="mediaProjection" >
+            android:foregroundServiceType="mediaProjection"
+            tools:targetApi="q">
         </service>
     </application>
 

--- a/exampleScreenCapturer/src/main/java/com/twilio/video/examples/screencapturer/ScreenCapturerActivity.java
+++ b/exampleScreenCapturer/src/main/java/com/twilio/video/examples/screencapturer/ScreenCapturerActivity.java
@@ -55,16 +55,6 @@ public class ScreenCapturerActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-    }
-
-    @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.screen_menu, menu);

--- a/exampleScreenCapturer/src/main/java/com/twilio/video/examples/screencapturer/ScreenCapturerActivity.java
+++ b/exampleScreenCapturer/src/main/java/com/twilio/video/examples/screencapturer/ScreenCapturerActivity.java
@@ -3,6 +3,7 @@ package com.twilio.video.examples.screencapturer;
 import android.content.Context;
 import android.content.Intent;
 import android.media.projection.MediaProjectionManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
@@ -48,18 +49,19 @@ public class ScreenCapturerActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_screen_capturer);
         localVideoView = (VideoView) findViewById(R.id.local_video);
+        if (Build.VERSION.SDK_INT >= 29) {
+            screenCapturerManager = new ScreenCapturerManager(this);
+        }
     }
 
     @Override
     protected void onStart() {
         super.onStart();
-        screenCapturerManager = new ScreenCapturerManager(this);
     }
 
     @Override
     protected void onStop() {
         super.onStop();
-        screenCapturerManager.unbindService();
     }
 
     @Override
@@ -81,14 +83,19 @@ public class ScreenCapturerActivity extends AppCompatActivity {
         switch (item.getItemId()) {
             case R.id.share_screen_menu_item:
                 String shareScreen = getString(R.string.share_screen);
-                screenCapturerManager.nextState();
                 if (item.getTitle().equals(shareScreen)) {
+                    if (Build.VERSION.SDK_INT >= 29) {
+                        screenCapturerManager.startForeground();
+                    }
                     if (screenCapturer == null) {
                         requestScreenCapturePermission();
                     } else {
                         startScreenCapture();
                     }
                 } else {
+                    if (Build.VERSION.SDK_INT >= 29) {
+                        screenCapturerManager.endForeground();
+                    }
                     stopScreenCapture();
                 }
 
@@ -146,6 +153,9 @@ public class ScreenCapturerActivity extends AppCompatActivity {
         if (screenVideoTrack != null) {
             screenVideoTrack.release();
             screenVideoTrack = null;
+        }
+        if (Build.VERSION.SDK_INT >= 29) {
+            screenCapturerManager.unbindService();
         }
         super.onDestroy();
     }

--- a/exampleScreenCapturer/src/main/java/com/twilio/video/examples/screencapturer/ScreenCapturerActivity.java
+++ b/exampleScreenCapturer/src/main/java/com/twilio/video/examples/screencapturer/ScreenCapturerActivity.java
@@ -1,9 +1,13 @@
 package com.twilio.video.examples.screencapturer;
 
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.ServiceConnection;
 import android.media.projection.MediaProjectionManager;
+import android.os.Build;
 import android.os.Bundle;
+import android.os.IBinder;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.Menu;
@@ -15,6 +19,7 @@ import android.widget.Toast;
 import com.twilio.video.LocalVideoTrack;
 import com.twilio.video.ScreenCapturer;
 import com.twilio.video.VideoView;
+import com.twilio.video.examples.screencapturer.ScreenCapturerService.LocalBinder;
 
 /**
  * This example demonstrates how to use the screen capturer
@@ -42,11 +47,29 @@ public class ScreenCapturerActivity extends AppCompatActivity {
         }
     };
 
+    ScreenCapturerService mService;
+    boolean mBound = false;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_screen_capturer);
         localVideoView = (VideoView) findViewById(R.id.local_video);
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        // Bind to ScreenCapturerService
+        Intent intent = new Intent(this, ScreenCapturerService.class);
+        bindService(intent, connection, Context.BIND_AUTO_CREATE);
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        unbindService(connection);
+        mBound = false;
     }
 
     @Override
@@ -70,12 +93,14 @@ public class ScreenCapturerActivity extends AppCompatActivity {
                 String shareScreen = getString(R.string.share_screen);
 
                 if (item.getTitle().equals(shareScreen)) {
+                    mService.startForeground();
                     if (screenCapturer == null) {
                         requestScreenCapturePermission();
                     } else {
                         startScreenCapture();
                     }
                 } else {
+                    mService.endForeground();
                     stopScreenCapture();
                 }
 
@@ -136,5 +161,28 @@ public class ScreenCapturerActivity extends AppCompatActivity {
         }
         super.onDestroy();
     }
+
+    /** Defines callbacks for service binding, passed to bindService() */
+    private ServiceConnection connection = new ServiceConnection() {
+
+        @Override
+        public void onServiceConnected(ComponentName className,
+                                       IBinder service) {
+            // We've bound to ScreenCapturerService, cast the IBinder and get ScreenCapturerService instance
+            LocalBinder binder = (LocalBinder) service;
+            mService = binder.getService();
+            mBound = true;
+            if (screenCaptureMenuItem != null) {
+                // Screen sharing only available on lollipop and up
+                screenCaptureMenuItem.setVisible(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP);
+            }
+        }
+
+        @Override
+        public void onServiceDisconnected(ComponentName arg0) {
+            mBound = false;
+        }
+
+    };
 
 }

--- a/exampleScreenCapturer/src/main/java/com/twilio/video/examples/screencapturer/ScreenCapturerManager.java
+++ b/exampleScreenCapturer/src/main/java/com/twilio/video/examples/screencapturer/ScreenCapturerManager.java
@@ -1,0 +1,67 @@
+package com.twilio.video.examples.screencapturer;
+
+import android.annotation.TargetApi;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.os.IBinder;
+
+@TargetApi(29)
+public class ScreenCapturerManager {
+    private ScreenCapturerService mService;
+    private Context mContext;
+    private State currentState = State.UNBIND_SERVICE;
+
+    /** Defines callbacks for service binding, passed to bindService() */
+    private ServiceConnection connection = new ServiceConnection() {
+
+        @Override
+        public void onServiceConnected(ComponentName className,
+                                       IBinder service) {
+            // We've bound to ScreenCapturerService, cast the IBinder and get ScreenCapturerService instance
+            ScreenCapturerService.LocalBinder binder = (ScreenCapturerService.LocalBinder) service;
+            mService = binder.getService();
+            currentState = State.BIND_SERVICE;
+        }
+
+        @Override
+        public void onServiceDisconnected(ComponentName arg0) {
+        }
+    };
+
+    /**
+     * An enum describing the possible states of a ScreenCapturerManager.
+     */
+    public enum State {
+        BIND_SERVICE,
+        START_FOREGROUND,
+        END_FOREGROUND,
+        UNBIND_SERVICE
+    }
+
+    ScreenCapturerManager(Context context) {
+        mContext = context;
+        bindService();
+    }
+
+    private void bindService() {
+        Intent intent = new Intent(mContext, ScreenCapturerService.class);
+        mContext.bindService(intent, connection, Context.BIND_AUTO_CREATE);
+    }
+
+    void startForeground() {
+        mService.startForeground();
+        currentState = State.START_FOREGROUND;
+    }
+
+    void endForeground() {
+        mService.endForeground();
+        currentState = State.END_FOREGROUND;
+    }
+
+    void unbindService() {
+        mContext.unbindService(connection);
+        currentState = State.UNBIND_SERVICE;
+    }
+}

--- a/exampleScreenCapturer/src/main/java/com/twilio/video/examples/screencapturer/ScreenCapturerService.java
+++ b/exampleScreenCapturer/src/main/java/com/twilio/video/examples/screencapturer/ScreenCapturerService.java
@@ -5,11 +5,87 @@ import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.Service;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.ServiceConnection;
 import android.os.Binder;
 import android.os.IBinder;
 import android.support.v4.app.NotificationCompat;
+
+
+class ScreenCapturerManager {
+    private ScreenCapturerService mService;
+    private Context mContext;
+    private State currentState = State.UNBIND_SERVICE;
+
+    /** Defines callbacks for service binding, passed to bindService() */
+    private ServiceConnection connection = new ServiceConnection() {
+
+        @Override
+        public void onServiceConnected(ComponentName className,
+                                       IBinder service) {
+            // We've bound to ScreenCapturerService, cast the IBinder and get ScreenCapturerService instance
+            ScreenCapturerService.LocalBinder binder = (ScreenCapturerService.LocalBinder) service;
+            mService = binder.getService();
+            currentState = State.BIND_SERVICE;
+        }
+
+        @Override
+        public void onServiceDisconnected(ComponentName arg0) {
+        }
+    };
+
+    /**
+     * An enum describing the possible states of a ScreenCapturerManager.
+     */
+    public enum State {
+        BIND_SERVICE,
+        START_FOREGROUND,
+        END_FOREGROUND,
+        UNBIND_SERVICE
+    }
+
+    ScreenCapturerManager(Context context) {
+        mContext = context;
+        bindService();
+    }
+
+    public void nextState() {
+        switch (currentState) {
+            case BIND_SERVICE:
+            case END_FOREGROUND:
+                startForeground();
+                break;
+            case START_FOREGROUND:
+                endForeground();
+                break;
+            case UNBIND_SERVICE:
+            default:
+                break;
+        }
+    }
+
+    private void bindService() {
+        Intent intent = new Intent(mContext, ScreenCapturerService.class);
+        mContext.bindService(intent, connection, Context.BIND_AUTO_CREATE);
+    }
+
+    private void startForeground() {
+        mService.startForeground();
+        currentState = State.START_FOREGROUND;
+    }
+
+    private void endForeground() {
+        mService.endForeground();
+        currentState = State.END_FOREGROUND;
+    }
+
+    void unbindService() {
+        mContext.unbindService(connection);
+        currentState = State.UNBIND_SERVICE;
+    }
+}
 
 @TargetApi(29)
 public class ScreenCapturerService extends Service {
@@ -20,7 +96,7 @@ public class ScreenCapturerService extends Service {
     private final IBinder binder = new LocalBinder();
 
     /**
-     * Class used for the client Binder.  Because we know this service always
+     * Class used for the client Binder.  We know this service always
      * runs in the same process as its clients, we don't need to deal with IPC.
      */
     public class LocalBinder extends Binder {

--- a/exampleScreenCapturer/src/main/java/com/twilio/video/examples/screencapturer/ScreenCapturerService.java
+++ b/exampleScreenCapturer/src/main/java/com/twilio/video/examples/screencapturer/ScreenCapturerService.java
@@ -5,87 +5,11 @@ import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.Service;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
-import android.content.ServiceConnection;
 import android.os.Binder;
 import android.os.IBinder;
 import android.support.v4.app.NotificationCompat;
-
-
-class ScreenCapturerManager {
-    private ScreenCapturerService mService;
-    private Context mContext;
-    private State currentState = State.UNBIND_SERVICE;
-
-    /** Defines callbacks for service binding, passed to bindService() */
-    private ServiceConnection connection = new ServiceConnection() {
-
-        @Override
-        public void onServiceConnected(ComponentName className,
-                                       IBinder service) {
-            // We've bound to ScreenCapturerService, cast the IBinder and get ScreenCapturerService instance
-            ScreenCapturerService.LocalBinder binder = (ScreenCapturerService.LocalBinder) service;
-            mService = binder.getService();
-            currentState = State.BIND_SERVICE;
-        }
-
-        @Override
-        public void onServiceDisconnected(ComponentName arg0) {
-        }
-    };
-
-    /**
-     * An enum describing the possible states of a ScreenCapturerManager.
-     */
-    public enum State {
-        BIND_SERVICE,
-        START_FOREGROUND,
-        END_FOREGROUND,
-        UNBIND_SERVICE
-    }
-
-    ScreenCapturerManager(Context context) {
-        mContext = context;
-        bindService();
-    }
-
-    public void nextState() {
-        switch (currentState) {
-            case BIND_SERVICE:
-            case END_FOREGROUND:
-                startForeground();
-                break;
-            case START_FOREGROUND:
-                endForeground();
-                break;
-            case UNBIND_SERVICE:
-            default:
-                break;
-        }
-    }
-
-    private void bindService() {
-        Intent intent = new Intent(mContext, ScreenCapturerService.class);
-        mContext.bindService(intent, connection, Context.BIND_AUTO_CREATE);
-    }
-
-    private void startForeground() {
-        mService.startForeground();
-        currentState = State.START_FOREGROUND;
-    }
-
-    private void endForeground() {
-        mService.endForeground();
-        currentState = State.END_FOREGROUND;
-    }
-
-    void unbindService() {
-        mContext.unbindService(connection);
-        currentState = State.UNBIND_SERVICE;
-    }
-}
 
 @TargetApi(29)
 public class ScreenCapturerService extends Service {

--- a/exampleScreenCapturer/src/main/java/com/twilio/video/examples/screencapturer/ScreenCapturerService.java
+++ b/exampleScreenCapturer/src/main/java/com/twilio/video/examples/screencapturer/ScreenCapturerService.java
@@ -1,0 +1,70 @@
+package com.twilio.video.examples.screencapturer;
+
+import android.annotation.TargetApi;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Binder;
+import android.os.IBinder;
+import android.support.v4.app.NotificationCompat;
+
+@TargetApi(29)
+public class ScreenCapturerService extends Service {
+    private static final String CHANNEL_ID = "screen_capture";
+    private static final String CHANNEL_NAME = "Screen_Capture";
+
+    // Binder given to clients
+    private final IBinder binder = new LocalBinder();
+
+    /**
+     * Class used for the client Binder.  Because we know this service always
+     * runs in the same process as its clients, we don't need to deal with IPC.
+     */
+    public class LocalBinder extends Binder {
+        public ScreenCapturerService getService() {
+            // Return this instance of ScreenCapturerService so clients can call public methods
+            return ScreenCapturerService.this;
+        }
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        return START_NOT_STICKY;
+    }
+
+    public void startForeground() {
+        NotificationChannel chan = new NotificationChannel(CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_NONE);
+        NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        assert manager != null;
+        manager.createNotificationChannel(chan);
+
+        final int notificationId = (int) System.currentTimeMillis();
+        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this, CHANNEL_ID);
+        Notification notification = notificationBuilder.setOngoing(true)
+                .setSmallIcon(R.drawable.ic_screen_share_white_24dp)
+                .setContentTitle("ScreenCapturerService is running in the foreground")
+                .setPriority(NotificationManager.IMPORTANCE_MIN)
+                .setCategory(Notification.CATEGORY_SERVICE)
+                .build();
+        startForeground(notificationId, notification);
+    }
+
+    public void endForeground() {
+        stopForeground(true);
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return binder;
+    }
+}


### PR DESCRIPTION
Android Q now requires developers to specify a [foreground service](https://developer.android.com/about/versions/10/features#fg-service-types) when using the MediaProjection API. Implemented `ScreenCapturerManager` and `ScreenCapturerService`, that start/stop foreground service before/after screen capture.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
