### PR TITLE
Migration to AndroidX

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,14 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.8',
-            'videoAndroid': '5.1.0'
+            'videoAndroid': '5.1.0',
+
+            // androidX
+            'appcompat': '1.0.2',
+            'legacy': '1.0.0',
+            'preference': '1.1.0',
+            'annotation': '1.1.0',
+            'material': '1.2.0-alpha02'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->

--- a/quickstartKotlin/build.gradle
+++ b/quickstartKotlin/build.gradle
@@ -65,8 +65,11 @@ dependencies {
     implementation "com.android.support.constraint:constraint-layout:${versions.constraintLayout}"
     implementation "com.twilio:video-android:${versions.videoAndroid}"
     implementation "com.koushikdutta.ion:ion:${versions.ion}"
-    implementation "com.android.support:appcompat-v7:${versions.supportLibrary}"
-    implementation "com.android.support:preference-v14:${versions.supportLibrary}"
-    implementation "com.android.support:design:${versions.supportLibrary}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+
+    implementation "androidx.legacy:legacy-support-v4:${versions.legacy}"
+    implementation "androidx.appcompat:appcompat:${versions.appcompat}"
+    implementation "androidx.preference:preference-ktx:${versions.preference}"
+    implementation "androidx.annotation:annotation:${versions.annotation}"
+    implementation "com.google.android.material:material:${versions.material}"
 }

--- a/quickstartKotlin/src/main/AndroidManifest.xml
+++ b/quickstartKotlin/src/main/AndroidManifest.xml
@@ -22,7 +22,6 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme"
         tools:ignore="GoogleAppIndexingWarning">
         <activity
             android:name=".VideoActivity"

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/CameraCapturerCompat.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/CameraCapturerCompat.kt
@@ -2,14 +2,13 @@ package com.twilio.video.quickstart.kotlin
 
 import android.content.Context
 import android.graphics.ImageFormat
-import android.hardware.camera2.CameraAccessException
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager
 import android.hardware.camera2.CameraMetadata
 import android.os.Build
-import android.support.annotation.RequiresApi
 import android.util.Log
 import android.util.Pair
+import androidx.annotation.RequiresApi
 import com.twilio.video.Camera2Capturer
 import com.twilio.video.CameraCapturer
 import com.twilio.video.VideoCapturer

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/SettingsActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/SettingsActivity.kt
@@ -2,14 +2,23 @@ package com.twilio.video.quickstart.kotlin
 
 import android.content.Intent
 import android.os.Bundle
-import android.preference.PreferenceManager
-import android.support.v7.app.AppCompatActivity
-import android.support.v7.preference.EditTextPreference
-import android.support.v7.preference.ListPreference
-import android.support.v7.preference.Preference
-import android.support.v7.preference.PreferenceFragmentCompat
 import android.view.MenuItem
-import com.twilio.video.*
+import androidx.appcompat.app.AppCompatActivity
+import androidx.preference.EditTextPreference
+import androidx.preference.ListPreference
+import androidx.preference.Preference
+import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.PreferenceManager
+import com.twilio.video.AudioCodec
+import com.twilio.video.G722Codec
+import com.twilio.video.H264Codec
+import com.twilio.video.IsacCodec
+import com.twilio.video.OpusCodec
+import com.twilio.video.PcmaCodec
+import com.twilio.video.PcmuCodec
+import com.twilio.video.VideoCodec
+import com.twilio.video.Vp8Codec
+import com.twilio.video.Vp9Codec
 import tvi.webrtc.MediaCodecVideoDecoder
 import tvi.webrtc.MediaCodecVideoEncoder
 
@@ -65,17 +74,17 @@ class SettingsActivity : AppCompatActivity() {
             setupCodecListPreference(AudioCodec::class.java,
                     PREF_AUDIO_CODEC,
                     PREF_AUDIO_CODEC_DEFAULT,
-                    findPreference(PREF_AUDIO_CODEC) as ListPreference)
+                    findPreference<ListPreference>(PREF_AUDIO_CODEC) as ListPreference)
             setupCodecListPreference(VideoCodec::class.java,
                     PREF_VIDEO_CODEC,
                     PREF_VIDEO_CODEC_DEFAULT,
-                    findPreference(PREF_VIDEO_CODEC) as ListPreference)
+                    findPreference<ListPreference>(PREF_VIDEO_CODEC) as ListPreference)
             setupSenderBandwidthPreferences(PREF_SENDER_MAX_AUDIO_BITRATE,
                     PREF_SENDER_MAX_AUDIO_BITRATE_DEFAULT,
-                    findPreference(PREF_SENDER_MAX_AUDIO_BITRATE) as EditTextPreference)
+                    findPreference<ListPreference>(PREF_SENDER_MAX_AUDIO_BITRATE) as EditTextPreference)
             setupSenderBandwidthPreferences(PREF_SENDER_MAX_VIDEO_BITRATE,
                     PREF_SENDER_MAX_VIDEO_BITRATE_DEFAULT,
-                    findPreference(PREF_SENDER_MAX_VIDEO_BITRATE) as EditTextPreference)
+                    findPreference<ListPreference>(PREF_SENDER_MAX_VIDEO_BITRATE) as EditTextPreference)
         }
 
 

--- a/quickstartKotlin/src/main/res/layout/activity_video.xml
+++ b/quickstartKotlin/src/main/res/layout/activity_video.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
+    android:theme="@style/AppTheme"
     tools:context="com.twilio.video.quickstart.kotlin.VideoActivity">
 
     <include layout="@layout/content_video" />
@@ -16,8 +17,8 @@
         android:layout_gravity="bottom|end"
         android:orientation="vertical" >
 
-        <android.support.design.widget.FloatingActionButton
-            android:id="@+id/switchCameraActionFab"
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/switch_camera_action_fab"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
@@ -25,8 +26,8 @@
             android:layout_marginBottom="@dimen/fab_margin"
             android:src="@drawable/ic_switch_camera_white_24dp" />
 
-        <android.support.design.widget.FloatingActionButton
-            android:id="@+id/localVideoActionFab"
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/local_video_action_fab"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/fab_margin"
@@ -34,16 +35,16 @@
             app:fabSize="mini"
             android:src="@drawable/ic_videocam_white_24dp" />
 
-        <android.support.design.widget.FloatingActionButton
-            android:id="@+id/muteActionFab"
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/mute_action_fab"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:fabSize="mini"
             android:layout_gravity="center"
             android:src="@drawable/ic_mic_white_24dp" />
 
-        <android.support.design.widget.FloatingActionButton
-            android:id="@+id/connectActionFab"
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/connect_action_fab"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="@dimen/fab_margin"
@@ -52,4 +53,4 @@
 
     </LinearLayout>
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/quickstartKotlin/src/main/res/values/strings.xml
+++ b/quickstartKotlin/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="room_status">status</string>
     <string name="permissions_needed">Camera and Microphone permissions needed. Please allow in App Settings for additional functionality.</string>
     <string name="turn_speaker_on">Speaker ON</string>
+    <string name="turn_speaker_off">Speaker OFF</string>
     <string name="error_retrieving_access_token">Error retrieving token</string>
     <string name="title_activity_settings">Settings</string>
     <string name="settings">Settings</string>

--- a/quickstartKotlin/src/main/res/values/styles.xml
+++ b/quickstartKotlin/src/main/res/values/styles.xml
@@ -14,4 +14,8 @@
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
     </style>
 
+    <style name="connectDialog" parent="Theme.AppCompat.Dialog">
+        <item name="android:windowNoTitle">true</item>
+    </style>
+
 </resources>

--- a/quickstartKotlin/src/main/res/xml/settings.xml
+++ b/quickstartKotlin/src/main/res/xml/settings.xml
@@ -1,38 +1,38 @@
-<android.support.v7.preference.PreferenceScreen
+<androidx.preference.PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android">
-    <android.support.v7.preference.PreferenceCategory
+    <androidx.preference.PreferenceCategory
         android:title="General">
-        <android.support.v7.preference.CheckBoxPreference
+        <androidx.preference.CheckBoxPreference
             android:key="enable_automatic_subscription"
             android:title="Enable Automatic Track Subscription"
             android:defaultValue="true"/>
-    </android.support.v7.preference.PreferenceCategory>
-    <android.support.v7.preference.PreferenceCategory
+    </androidx.preference.PreferenceCategory>
+    <androidx.preference.PreferenceCategory
         android:title="@string/codec_title">
-        <android.support.v7.preference.ListPreference
+        <androidx.preference.ListPreference
             android:key="audio_codec"
             android:negativeButtonText="@null"
             android:positiveButtonText="@null"
             android:title="@string/pref_title_audio_codec" />
-        <android.support.v7.preference.ListPreference
+        <androidx.preference.ListPreference
             android:key="video_codec"
             android:negativeButtonText="@null"
             android:positiveButtonText="@null"
             android:title="@string/pref_title_video_codec" />
-        <android.support.v7.preference.CheckBoxPreference
+        <androidx.preference.CheckBoxPreference
             android:key="vp8_simulcast"
             android:title="@string/vp8_simulcast"
             android:defaultValue="false"/>
-    </android.support.v7.preference.PreferenceCategory>
-    <android.support.v7.preference.PreferenceCategory
+    </androidx.preference.PreferenceCategory>
+    <androidx.preference.PreferenceCategory
         android:title="@string/sender_bandwidth_constraints">
-        <android.support.v7.preference.EditTextPreference
+        <androidx.preference.EditTextPreference
             android:key="sender_max_audio_bitrate"
             android:title="@string/max_audio_bitrate"
             android:defaultValue="0"/>
-        <android.support.v7.preference.EditTextPreference
+        <androidx.preference.EditTextPreference
             android:key="sender_max_video_bitrate"
             android:title="@string/max_video_bitrate"
             android:defaultValue="0" />
-    </android.support.v7.preference.PreferenceCategory>
-</android.support.v7.preference.PreferenceScreen>
+    </androidx.preference.PreferenceCategory>
+</androidx.preference.PreferenceScreen>


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**
1) <string name="turn_speaker_off">Speaker OFF</string> was missing from strings.xml

2) The label "Connected to <room>" fails to follow the lifecycle of the connection. see quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt

3) several other androidx related fixes

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
