### PR TITLE
Update to 5.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.8',
-            'videoAndroid': '5.1.0'
+            'videoAndroid': '5.1.1'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->


### PR DESCRIPTION
### 5.1.1 (February 14th, 2020)

* Programmable Video Android SDK 5.1.1 [[bintray]](https://bintray.com/twilio/releases/video-android/5.1.1), [[docs]](https://twilio.github.io/twilio-video-android/docs/5.1.1/)

Enhancements

- Reduced bandwidth usage for Insights reporting by up to 75%.
- Data track per-message size limit has been increased to 64 KB.

Bug Fixes

- Fixed a crash which could occur when destroying a Room while the TCP handshake for the
signaling connection is in progress.
- Fixed intermittent crash when sending data on a data track while in the process of closing the
track due to remote participant disconnect.

Known issues

- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. As a result, tracks published after a `Room.State.RECONNECTED` event might not be subscribed to by a `RemoteParticipant`.

Size Report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| universal       | 22.8MB          |
| armeabi-v7a     | 5MB             |
| arm64-v8a       | 5.9MB           |
| x86             | 6.2MB           |
| x86_64          | 6.3MB           |