### PR TITLE
Update to 5.2.0: Remote Participant Network Quality

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.8',
-            'videoAndroid': '5.1.2'
+            'videoAndroid': '5.2.0'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.8',
-            'videoAndroid': '5.2.0-rc1'
+            'videoAndroid': '5.2.0'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->
@@ -53,12 +53,5 @@ allprojects {
         google()
         jcenter()
         mavenCentral()
-        maven {
-            url  "https://twilio.bintray.com/internal-releases"
-            credentials {
-                username "${getSecretProperty("BINTRAY_USERNAME", null)}"
-                password "${getSecretProperty("BINTRAY_PASSWORD", null)}"
-            }
-        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.8',
-            'videoAndroid': '5.2.0'
+            'videoAndroid': '5.2.0-rc1'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->
@@ -53,5 +53,12 @@ allprojects {
         google()
         jcenter()
         mavenCentral()
+        maven {
+            url  "https://twilio.bintray.com/internal-releases"
+            credentials {
+                username "${getSecretProperty("BINTRAY_USERNAME", null)}"
+                password "${getSecretProperty("BINTRAY_PASSWORD", null)}"
+            }
+        }
     }
 }

--- a/exampleMultipartyVideo/src/main/java/com/twilio/examplemultipartyvideo/MultiPartyActivity.java
+++ b/exampleMultipartyVideo/src/main/java/com/twilio/examplemultipartyvideo/MultiPartyActivity.java
@@ -562,6 +562,31 @@ public class MultiPartyActivity extends AppCompatActivity {
         dominantSpeakerImg.setVisibility(GONE);
     }
 
+    private void updateLocalParticipantNetworkQuality(NetworkQualityLevel networkQualityLevel) {
+        if (networkQualityLevelImage.getVisibility() != VISIBLE) {
+            networkQualityLevelImage.setVisibility(VISIBLE);
+        }
+
+        networkQualityLevelImage.setImageResource(getNetworkQualityLevelImage(networkQualityLevel));
+    }
+    private int getNetworkQualityLevelImage(NetworkQualityLevel networkQualityLevel) {
+        int networkQualityLevelImage = R.drawable.network_quality_level_0;
+
+        if (networkQualityLevel == NetworkQualityLevel.NETWORK_QUALITY_LEVEL_ONE) {
+            networkQualityLevelImage = R.drawable.network_quality_level_1;
+        } else if (networkQualityLevel == NetworkQualityLevel.NETWORK_QUALITY_LEVEL_TWO) {
+            networkQualityLevelImage = R.drawable.network_quality_level_2;
+        } else if (networkQualityLevel == NetworkQualityLevel.NETWORK_QUALITY_LEVEL_THREE) {
+            networkQualityLevelImage = R.drawable.network_quality_level_3;
+        } else if (networkQualityLevel == NetworkQualityLevel.NETWORK_QUALITY_LEVEL_FOUR) {
+            networkQualityLevelImage = R.drawable.network_quality_level_4;
+        } else if (networkQualityLevel == NetworkQualityLevel.NETWORK_QUALITY_LEVEL_FIVE) {
+            networkQualityLevelImage = R.drawable.network_quality_level_5;
+        }
+
+        return networkQualityLevelImage;
+    }
+
     /*
      * Room events listener
      */
@@ -569,7 +594,7 @@ public class MultiPartyActivity extends AppCompatActivity {
         return new Room.Listener() {
             @Override
             public void onConnected(Room room) {
-                networkQualityLevelImage.setVisibility(VISIBLE);
+                networkQualityLevelImage.setVisibility(GONE);
                 localParticipant = room.getLocalParticipant();
                 localParticipant.setListener(new LocalParticipant.Listener() {
                     @Override
@@ -604,20 +629,12 @@ public class MultiPartyActivity extends AppCompatActivity {
 
                     @Override
                     public void onNetworkQualityLevelChanged(@NonNull LocalParticipant localParticipant, @NonNull NetworkQualityLevel networkQualityLevel) {
-                        if (networkQualityLevel == NetworkQualityLevel.NETWORK_QUALITY_LEVEL_UNKNOWN ||
-                                networkQualityLevel == NetworkQualityLevel.NETWORK_QUALITY_LEVEL_ZERO) {
-                            networkQualityLevelImage.setImageResource(R.drawable.network_quality_level_0);
-                        } else if (networkQualityLevel == NetworkQualityLevel.NETWORK_QUALITY_LEVEL_ONE) {
-                            networkQualityLevelImage.setImageResource(R.drawable.network_quality_level_1);
-                        } else if (networkQualityLevel == NetworkQualityLevel.NETWORK_QUALITY_LEVEL_TWO) {
-                            networkQualityLevelImage.setImageResource(R.drawable.network_quality_level_2);
-                        } else if (networkQualityLevel == NetworkQualityLevel.NETWORK_QUALITY_LEVEL_THREE) {
-                            networkQualityLevelImage.setImageResource(R.drawable.network_quality_level_3);
-                        } else if (networkQualityLevel == NetworkQualityLevel.NETWORK_QUALITY_LEVEL_FOUR) {
-                            networkQualityLevelImage.setImageResource(R.drawable.network_quality_level_4);
-                        } else if (networkQualityLevel == NetworkQualityLevel.NETWORK_QUALITY_LEVEL_FIVE) {
-                            networkQualityLevelImage.setImageResource(R.drawable.network_quality_level_5);
-                        }
+                        Log.i(TAG, String.format("onNetworkQualityLevelChanged: " +
+                                        "[LocalParticipant: identity=%s], " +
+                                        "[NetworkQualityLevel: %s]",
+                                        localParticipant.getIdentity(),
+                                        networkQualityLevel));
+                        updateLocalParticipantNetworkQuality(networkQualityLevel);
                     }
                 });
                 videoStatusTextView.setText(String.format("Connected to %s", room.getName()));

--- a/exampleMultipartyVideo/src/main/java/com/twilio/examplemultipartyvideo/MultiPartyActivity.java
+++ b/exampleMultipartyVideo/src/main/java/com/twilio/examplemultipartyvideo/MultiPartyActivity.java
@@ -117,7 +117,6 @@ public class MultiPartyActivity extends AppCompatActivity {
     /*
      * Android application UI elements
      */
-    private TextView videoStatusTextView;
     private CameraCapturer cameraCapturerCompat;
     private LocalAudioTrack localAudioTrack;
     private LocalVideoTrack localVideoTrack;
@@ -146,7 +145,6 @@ public class MultiPartyActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_video);
 
-        videoStatusTextView = findViewById(R.id.videoStatusText);
         reconnectingProgressBar = findViewById(R.id.reconnecting_progress_bar);
 
         connectActionFab = findViewById(R.id.connect_action_fab);
@@ -255,7 +253,6 @@ public class MultiPartyActivity extends AppCompatActivity {
             reconnectingProgressBar.setVisibility((room.getState() != Room.State.RECONNECTING) ?
                     GONE :
                     VISIBLE);
-            videoStatusTextView.setText("Connected to " + room.getName());
 
             if (room.getDominantSpeaker() != null) {
                 currentDominantSpeakerImg.setVisibility(VISIBLE);
@@ -483,7 +480,6 @@ public class MultiPartyActivity extends AppCompatActivity {
      */
     private void addRemoteParticipant(RemoteParticipant remoteParticipant) {
         remoteParticipantIdentity = remoteParticipant.getIdentity();
-        videoStatusTextView.setText(String.format("RemoteParticipant %s joined", remoteParticipantIdentity));
 
         /*
          * Add remote participant renderer
@@ -526,7 +522,6 @@ public class MultiPartyActivity extends AppCompatActivity {
      * Called when remote participant leaves the room
      */
     private void removeRemoteParticipant(RemoteParticipant remoteParticipant) {
-        videoStatusTextView.setText(String.format("RemoteParticipant %s left", remoteParticipant.getIdentity()));
         if (!remoteParticipant.getIdentity().equals(remoteParticipantIdentity)) {
             return;
         }
@@ -637,7 +632,6 @@ public class MultiPartyActivity extends AppCompatActivity {
                         updateLocalParticipantNetworkQuality(networkQualityLevel);
                     }
                 });
-                videoStatusTextView.setText(String.format("Connected to %s", room.getName()));
                 setTitle(room.getName());
 
                 for (RemoteParticipant remoteParticipant : room.getRemoteParticipants()) {
@@ -647,19 +641,16 @@ public class MultiPartyActivity extends AppCompatActivity {
 
             @Override
             public void onReconnecting(@NonNull Room room, @NonNull TwilioException twilioException) {
-                videoStatusTextView.setText(String.format("Reconnecting to %s", room.getName()));
                 reconnectingProgressBar.setVisibility(VISIBLE);
             }
 
             @Override
             public void onReconnected(@NonNull Room room) {
-                videoStatusTextView.setText(String.format("Connected to %s", room.getName()));
                 reconnectingProgressBar.setVisibility(GONE);
             }
 
             @Override
             public void onConnectFailure(@NonNull Room room, @NonNull TwilioException e) {
-                videoStatusTextView.setText(R.string.connect_failed);
                 configureAudio(false);
                 intializeUI();
             }
@@ -668,7 +659,6 @@ public class MultiPartyActivity extends AppCompatActivity {
             public void onDisconnected(Room room, TwilioException e) {
                 localParticipantNetworkQualityLevelImageView.setVisibility(GONE);
                 localParticipant = null;
-                videoStatusTextView.setText(String.format("Disconnected from %s", room.getName()));
                 reconnectingProgressBar.setVisibility(GONE);
                 MultiPartyActivity.this.room = null;
                 // Only reinitialize the UI if disconnect was not called from onDestroy()
@@ -743,7 +733,6 @@ public class MultiPartyActivity extends AppCompatActivity {
                         remoteAudioTrackPublication.isTrackEnabled(),
                         remoteAudioTrackPublication.isTrackSubscribed(),
                         remoteAudioTrackPublication.getTrackName()));
-                videoStatusTextView.setText("onAudioTrackPublished");
             }
 
             @Override
@@ -758,7 +747,6 @@ public class MultiPartyActivity extends AppCompatActivity {
                         remoteAudioTrackPublication.isTrackEnabled(),
                         remoteAudioTrackPublication.isTrackSubscribed(),
                         remoteAudioTrackPublication.getTrackName()));
-                videoStatusTextView.setText("onAudioTrackUnpublished");
             }
 
             @Override
@@ -773,7 +761,6 @@ public class MultiPartyActivity extends AppCompatActivity {
                         remoteDataTrackPublication.isTrackEnabled(),
                         remoteDataTrackPublication.isTrackSubscribed(),
                         remoteDataTrackPublication.getTrackName()));
-                videoStatusTextView.setText("onDataTrackPublished");
             }
 
             @Override
@@ -788,7 +775,6 @@ public class MultiPartyActivity extends AppCompatActivity {
                         remoteDataTrackPublication.isTrackEnabled(),
                         remoteDataTrackPublication.isTrackSubscribed(),
                         remoteDataTrackPublication.getTrackName()));
-                videoStatusTextView.setText("onDataTrackUnpublished");
             }
 
             @Override
@@ -803,7 +789,6 @@ public class MultiPartyActivity extends AppCompatActivity {
                         remoteVideoTrackPublication.isTrackEnabled(),
                         remoteVideoTrackPublication.isTrackSubscribed(),
                         remoteVideoTrackPublication.getTrackName()));
-                videoStatusTextView.setText("onVideoTrackPublished");
             }
 
             @Override
@@ -818,7 +803,6 @@ public class MultiPartyActivity extends AppCompatActivity {
                         remoteVideoTrackPublication.isTrackEnabled(),
                         remoteVideoTrackPublication.isTrackSubscribed(),
                         remoteVideoTrackPublication.getTrackName()));
-                videoStatusTextView.setText("onVideoTrackUnpublished");
             }
 
             @Override
@@ -832,7 +816,6 @@ public class MultiPartyActivity extends AppCompatActivity {
                         remoteAudioTrack.isEnabled(),
                         remoteAudioTrack.isPlaybackEnabled(),
                         remoteAudioTrack.getName()));
-                videoStatusTextView.setText("onAudioTrackSubscribed");
             }
 
             @Override
@@ -846,7 +829,6 @@ public class MultiPartyActivity extends AppCompatActivity {
                         remoteAudioTrack.isEnabled(),
                         remoteAudioTrack.isPlaybackEnabled(),
                         remoteAudioTrack.getName()));
-                videoStatusTextView.setText("onAudioTrackUnsubscribed");
             }
 
             @Override
@@ -862,7 +844,6 @@ public class MultiPartyActivity extends AppCompatActivity {
                         remoteAudioTrackPublication.getTrackName(),
                         twilioException.getCode(),
                         twilioException.getMessage()));
-                videoStatusTextView.setText("onAudioTrackSubscriptionFailed");
             }
 
             @Override
@@ -875,7 +856,6 @@ public class MultiPartyActivity extends AppCompatActivity {
                         remoteParticipant.getIdentity(),
                         remoteDataTrack.isEnabled(),
                         remoteDataTrack.getName()));
-                videoStatusTextView.setText("onDataTrackSubscribed");
             }
 
             @Override
@@ -888,7 +868,6 @@ public class MultiPartyActivity extends AppCompatActivity {
                         remoteParticipant.getIdentity(),
                         remoteDataTrack.isEnabled(),
                         remoteDataTrack.getName()));
-                videoStatusTextView.setText("onDataTrackUnsubscribed");
             }
 
             @Override
@@ -904,7 +883,6 @@ public class MultiPartyActivity extends AppCompatActivity {
                         remoteDataTrackPublication.getTrackName(),
                         twilioException.getCode(),
                         twilioException.getMessage()));
-                videoStatusTextView.setText("onDataTrackSubscriptionFailed");
             }
 
             @Override
@@ -917,7 +895,6 @@ public class MultiPartyActivity extends AppCompatActivity {
                         remoteParticipant.getIdentity(),
                         remoteVideoTrack.isEnabled(),
                         remoteVideoTrack.getName()));
-                videoStatusTextView.setText("onVideoTrackSubscribed");
                 addRemoteParticipantVideo(remoteParticipant, remoteVideoTrack);
             }
 
@@ -931,7 +908,6 @@ public class MultiPartyActivity extends AppCompatActivity {
                         remoteParticipant.getIdentity(),
                         remoteVideoTrack.isEnabled(),
                         remoteVideoTrack.getName()));
-                videoStatusTextView.setText("onVideoTrackUnsubscribed");
                 removeParticipantVideo(remoteParticipant);
             }
 
@@ -948,7 +924,6 @@ public class MultiPartyActivity extends AppCompatActivity {
                         remoteVideoTrackPublication.getTrackName(),
                         twilioException.getCode(),
                         twilioException.getMessage()));
-                videoStatusTextView.setText("onVideoTrackSubscriptionFailed");
                 Snackbar.make(connectActionFab,
                         String.format("Failed to subscribe to %s video track",
                                 remoteParticipant.getIdentity()),

--- a/exampleMultipartyVideo/src/main/java/com/twilio/examplemultipartyvideo/MultiPartyActivity.java
+++ b/exampleMultipartyVideo/src/main/java/com/twilio/examplemultipartyvideo/MultiPartyActivity.java
@@ -732,8 +732,8 @@ public class MultiPartyActivity extends AppCompatActivity {
     private RemoteParticipant.Listener remoteParticipantListener() {
         return new RemoteParticipant.Listener() {
             @Override
-            public void onAudioTrackPublished(RemoteParticipant remoteParticipant,
-                                              RemoteAudioTrackPublication remoteAudioTrackPublication) {
+            public void onAudioTrackPublished(@NonNull RemoteParticipant remoteParticipant,
+                                              @NonNull RemoteAudioTrackPublication remoteAudioTrackPublication) {
                 Log.i(TAG, String.format("onAudioTrackPublished: " +
                                 "[RemoteParticipant: identity=%s], " +
                                 "[RemoteAudioTrackPublication: sid=%s, enabled=%b, " +
@@ -747,8 +747,8 @@ public class MultiPartyActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onAudioTrackUnpublished(RemoteParticipant remoteParticipant,
-                                                RemoteAudioTrackPublication remoteAudioTrackPublication) {
+            public void onAudioTrackUnpublished(@NonNull RemoteParticipant remoteParticipant,
+                                                @NonNull RemoteAudioTrackPublication remoteAudioTrackPublication) {
                 Log.i(TAG, String.format("onAudioTrackUnpublished: " +
                                 "[RemoteParticipant: identity=%s], " +
                                 "[RemoteAudioTrackPublication: sid=%s, enabled=%b, " +
@@ -762,8 +762,8 @@ public class MultiPartyActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onDataTrackPublished(RemoteParticipant remoteParticipant,
-                                             RemoteDataTrackPublication remoteDataTrackPublication) {
+            public void onDataTrackPublished(@NonNull RemoteParticipant remoteParticipant,
+                                             @NonNull RemoteDataTrackPublication remoteDataTrackPublication) {
                 Log.i(TAG, String.format("onDataTrackPublished: " +
                                 "[RemoteParticipant: identity=%s], " +
                                 "[RemoteDataTrackPublication: sid=%s, enabled=%b, " +
@@ -777,8 +777,8 @@ public class MultiPartyActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onDataTrackUnpublished(RemoteParticipant remoteParticipant,
-                                               RemoteDataTrackPublication remoteDataTrackPublication) {
+            public void onDataTrackUnpublished(@NonNull RemoteParticipant remoteParticipant,
+                                               @NonNull RemoteDataTrackPublication remoteDataTrackPublication) {
                 Log.i(TAG, String.format("onDataTrackUnpublished: " +
                                 "[RemoteParticipant: identity=%s], " +
                                 "[RemoteDataTrackPublication: sid=%s, enabled=%b, " +
@@ -792,8 +792,8 @@ public class MultiPartyActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onVideoTrackPublished(RemoteParticipant remoteParticipant,
-                                              RemoteVideoTrackPublication remoteVideoTrackPublication) {
+            public void onVideoTrackPublished(@NonNull RemoteParticipant remoteParticipant,
+                                              @NonNull RemoteVideoTrackPublication remoteVideoTrackPublication) {
                 Log.i(TAG, String.format("onVideoTrackPublished: " +
                                 "[RemoteParticipant: identity=%s], " +
                                 "[RemoteVideoTrackPublication: sid=%s, enabled=%b, " +
@@ -807,8 +807,8 @@ public class MultiPartyActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onVideoTrackUnpublished(RemoteParticipant remoteParticipant,
-                                                RemoteVideoTrackPublication remoteVideoTrackPublication) {
+            public void onVideoTrackUnpublished(@NonNull RemoteParticipant remoteParticipant,
+                                                @NonNull RemoteVideoTrackPublication remoteVideoTrackPublication) {
                 Log.i(TAG, String.format("onVideoTrackUnpublished: " +
                                 "[RemoteParticipant: identity=%s], " +
                                 "[RemoteVideoTrackPublication: sid=%s, enabled=%b, " +
@@ -822,9 +822,9 @@ public class MultiPartyActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onAudioTrackSubscribed(RemoteParticipant remoteParticipant,
-                                               RemoteAudioTrackPublication remoteAudioTrackPublication,
-                                               RemoteAudioTrack remoteAudioTrack) {
+            public void onAudioTrackSubscribed(@NonNull RemoteParticipant remoteParticipant,
+                                               @NonNull RemoteAudioTrackPublication remoteAudioTrackPublication,
+                                               @NonNull RemoteAudioTrack remoteAudioTrack) {
                 Log.i(TAG, String.format("onAudioTrackSubscribed: " +
                                 "[RemoteParticipant: identity=%s], " +
                                 "[RemoteAudioTrack: enabled=%b, playbackEnabled=%b, name=%s]",
@@ -836,9 +836,9 @@ public class MultiPartyActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onAudioTrackUnsubscribed(RemoteParticipant remoteParticipant,
-                                                 RemoteAudioTrackPublication remoteAudioTrackPublication,
-                                                 RemoteAudioTrack remoteAudioTrack) {
+            public void onAudioTrackUnsubscribed(@NonNull RemoteParticipant remoteParticipant,
+                                                 @NonNull RemoteAudioTrackPublication remoteAudioTrackPublication,
+                                                 @NonNull RemoteAudioTrack remoteAudioTrack) {
                 Log.i(TAG, String.format("onAudioTrackUnsubscribed: " +
                                 "[RemoteParticipant: identity=%s], " +
                                 "[RemoteAudioTrack: enabled=%b, playbackEnabled=%b, name=%s]",
@@ -850,9 +850,9 @@ public class MultiPartyActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onAudioTrackSubscriptionFailed(RemoteParticipant remoteParticipant,
-                                                       RemoteAudioTrackPublication remoteAudioTrackPublication,
-                                                       TwilioException twilioException) {
+            public void onAudioTrackSubscriptionFailed(@NonNull RemoteParticipant remoteParticipant,
+                                                       @NonNull RemoteAudioTrackPublication remoteAudioTrackPublication,
+                                                       @NonNull TwilioException twilioException) {
                 Log.i(TAG, String.format("onAudioTrackSubscriptionFailed: " +
                                 "[RemoteParticipant: identity=%s], " +
                                 "[RemoteAudioTrackPublication: sid=%b, name=%s]" +
@@ -866,9 +866,9 @@ public class MultiPartyActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onDataTrackSubscribed(RemoteParticipant remoteParticipant,
-                                              RemoteDataTrackPublication remoteDataTrackPublication,
-                                              RemoteDataTrack remoteDataTrack) {
+            public void onDataTrackSubscribed(@NonNull RemoteParticipant remoteParticipant,
+                                              @NonNull RemoteDataTrackPublication remoteDataTrackPublication,
+                                              @NonNull RemoteDataTrack remoteDataTrack) {
                 Log.i(TAG, String.format("onDataTrackSubscribed: " +
                                 "[RemoteParticipant: identity=%s], " +
                                 "[RemoteDataTrack: enabled=%b, name=%s]",
@@ -879,9 +879,9 @@ public class MultiPartyActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onDataTrackUnsubscribed(RemoteParticipant remoteParticipant,
-                                                RemoteDataTrackPublication remoteDataTrackPublication,
-                                                RemoteDataTrack remoteDataTrack) {
+            public void onDataTrackUnsubscribed(@NonNull RemoteParticipant remoteParticipant,
+                                                @NonNull RemoteDataTrackPublication remoteDataTrackPublication,
+                                                @NonNull RemoteDataTrack remoteDataTrack) {
                 Log.i(TAG, String.format("onDataTrackUnsubscribed: " +
                                 "[RemoteParticipant: identity=%s], " +
                                 "[RemoteDataTrack: enabled=%b, name=%s]",
@@ -892,9 +892,9 @@ public class MultiPartyActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onDataTrackSubscriptionFailed(RemoteParticipant remoteParticipant,
-                                                      RemoteDataTrackPublication remoteDataTrackPublication,
-                                                      TwilioException twilioException) {
+            public void onDataTrackSubscriptionFailed(@NonNull RemoteParticipant remoteParticipant,
+                                                      @NonNull RemoteDataTrackPublication remoteDataTrackPublication,
+                                                      @NonNull TwilioException twilioException) {
                 Log.i(TAG, String.format("onDataTrackSubscriptionFailed: " +
                                 "[RemoteParticipant: identity=%s], " +
                                 "[RemoteDataTrackPublication: sid=%b, name=%s]" +
@@ -908,9 +908,9 @@ public class MultiPartyActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onVideoTrackSubscribed(RemoteParticipant remoteParticipant,
-                                               RemoteVideoTrackPublication remoteVideoTrackPublication,
-                                               RemoteVideoTrack remoteVideoTrack) {
+            public void onVideoTrackSubscribed(@NonNull RemoteParticipant remoteParticipant,
+                                               @NonNull RemoteVideoTrackPublication remoteVideoTrackPublication,
+                                               @NonNull RemoteVideoTrack remoteVideoTrack) {
                 Log.i(TAG, String.format("onVideoTrackSubscribed: " +
                                 "[RemoteParticipant: identity=%s], " +
                                 "[RemoteVideoTrack: enabled=%b, name=%s]",
@@ -922,9 +922,9 @@ public class MultiPartyActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onVideoTrackUnsubscribed(RemoteParticipant remoteParticipant,
-                                                 RemoteVideoTrackPublication remoteVideoTrackPublication,
-                                                 RemoteVideoTrack remoteVideoTrack) {
+            public void onVideoTrackUnsubscribed(@NonNull RemoteParticipant remoteParticipant,
+                                                 @NonNull RemoteVideoTrackPublication remoteVideoTrackPublication,
+                                                 @NonNull RemoteVideoTrack remoteVideoTrack) {
                 Log.i(TAG, String.format("onVideoTrackUnsubscribed: " +
                                 "[RemoteParticipant: identity=%s], " +
                                 "[RemoteVideoTrack: enabled=%b, name=%s]",
@@ -936,9 +936,9 @@ public class MultiPartyActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onVideoTrackSubscriptionFailed(RemoteParticipant remoteParticipant,
-                                                       RemoteVideoTrackPublication remoteVideoTrackPublication,
-                                                       TwilioException twilioException) {
+            public void onVideoTrackSubscriptionFailed(@NonNull RemoteParticipant remoteParticipant,
+                                                       @NonNull RemoteVideoTrackPublication remoteVideoTrackPublication,
+                                                       @NonNull TwilioException twilioException) {
                 Log.i(TAG, String.format("onVideoTrackSubscriptionFailed: " +
                                 "[RemoteParticipant: identity=%s], " +
                                 "[RemoteVideoTrackPublication: sid=%b, name=%s]" +
@@ -957,26 +957,26 @@ public class MultiPartyActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onAudioTrackEnabled(RemoteParticipant remoteParticipant,
-                                            RemoteAudioTrackPublication remoteAudioTrackPublication) {
+            public void onAudioTrackEnabled(@NonNull RemoteParticipant remoteParticipant,
+                                            @NonNull RemoteAudioTrackPublication remoteAudioTrackPublication) {
 
             }
 
             @Override
-            public void onAudioTrackDisabled(RemoteParticipant remoteParticipant,
-                                             RemoteAudioTrackPublication remoteAudioTrackPublication) {
+            public void onAudioTrackDisabled(@NonNull RemoteParticipant remoteParticipant,
+                                             @NonNull RemoteAudioTrackPublication remoteAudioTrackPublication) {
 
             }
 
             @Override
-            public void onVideoTrackEnabled(RemoteParticipant remoteParticipant,
-                                            RemoteVideoTrackPublication remoteVideoTrackPublication) {
+            public void onVideoTrackEnabled(@NonNull RemoteParticipant remoteParticipant,
+                                            @NonNull RemoteVideoTrackPublication remoteVideoTrackPublication) {
 
             }
 
             @Override
-            public void onVideoTrackDisabled(RemoteParticipant remoteParticipant,
-                                             RemoteVideoTrackPublication remoteVideoTrackPublication) {
+            public void onVideoTrackDisabled(@NonNull RemoteParticipant remoteParticipant,
+                                             @NonNull RemoteVideoTrackPublication remoteVideoTrackPublication) {
 
             }
         };

--- a/exampleMultipartyVideo/src/main/java/com/twilio/examplemultipartyvideo/MultiPartyActivity.java
+++ b/exampleMultipartyVideo/src/main/java/com/twilio/examplemultipartyvideo/MultiPartyActivity.java
@@ -129,7 +129,7 @@ public class MultiPartyActivity extends AppCompatActivity {
     private AlertDialog connectDialog;
     private AudioManager audioManager;
     private String remoteParticipantIdentity;
-    private ImageView networkQualityLevelImage;
+    private ImageView localParticipantNetworkQualityLevelImageView;
 
     private int previousAudioMode;
     private boolean previousMicrophoneMute;
@@ -153,7 +153,7 @@ public class MultiPartyActivity extends AppCompatActivity {
         switchCameraActionFab = findViewById(R.id.switch_camera_action_fab);
         localVideoActionFab = findViewById(R.id.local_video_action_fab);
         muteActionFab = findViewById(R.id.mute_action_fab);
-        networkQualityLevelImage = findViewById(R.id.network_quality_level);
+        localParticipantNetworkQualityLevelImageView = findViewById(R.id.local_network_quality_level);
 
         initializeParticipantContainers();
         /*
@@ -563,11 +563,11 @@ public class MultiPartyActivity extends AppCompatActivity {
     }
 
     private void updateLocalParticipantNetworkQuality(NetworkQualityLevel networkQualityLevel) {
-        if (networkQualityLevelImage.getVisibility() != VISIBLE) {
-            networkQualityLevelImage.setVisibility(VISIBLE);
+        if (localParticipantNetworkQualityLevelImageView.getVisibility() != VISIBLE) {
+            localParticipantNetworkQualityLevelImageView.setVisibility(VISIBLE);
         }
 
-        networkQualityLevelImage.setImageResource(getNetworkQualityLevelImage(networkQualityLevel));
+        localParticipantNetworkQualityLevelImageView.setImageResource(getNetworkQualityLevelImage(networkQualityLevel));
     }
     private int getNetworkQualityLevelImage(NetworkQualityLevel networkQualityLevel) {
         int networkQualityLevelImage = R.drawable.network_quality_level_0;
@@ -594,7 +594,7 @@ public class MultiPartyActivity extends AppCompatActivity {
         return new Room.Listener() {
             @Override
             public void onConnected(Room room) {
-                networkQualityLevelImage.setVisibility(GONE);
+                localParticipantNetworkQualityLevelImageView.setVisibility(GONE);
                 localParticipant = room.getLocalParticipant();
                 localParticipant.setListener(new LocalParticipant.Listener() {
                     @Override
@@ -666,7 +666,7 @@ public class MultiPartyActivity extends AppCompatActivity {
 
             @Override
             public void onDisconnected(Room room, TwilioException e) {
-                networkQualityLevelImage.setVisibility(GONE);
+                localParticipantNetworkQualityLevelImageView.setVisibility(GONE);
                 localParticipant = null;
                 videoStatusTextView.setText(String.format("Disconnected from %s", room.getName()));
                 reconnectingProgressBar.setVisibility(GONE);

--- a/exampleMultipartyVideo/src/main/java/com/twilio/examplemultipartyvideo/ParticipantView.java
+++ b/exampleMultipartyVideo/src/main/java/com/twilio/examplemultipartyvideo/ParticipantView.java
@@ -10,6 +10,7 @@ import com.twilio.video.VideoTextureView;
 public class ParticipantView extends RelativeLayout {
     private VideoTextureView videoView;
     private ImageView dominantSpeakerImg;
+    private ImageView networkQualityLevelImageView;
 
     public ParticipantView(Context context) {
         super(context);
@@ -26,6 +27,7 @@ public class ParticipantView extends RelativeLayout {
     private void init() {
         videoView = findViewById(R.id.video_view);
         dominantSpeakerImg = findViewById(R.id.dominant_speaker_img);
+        networkQualityLevelImageView = findViewById(R.id.network_quality_level);
     }
 
     public VideoTextureView getVideoView() {
@@ -35,6 +37,8 @@ public class ParticipantView extends RelativeLayout {
     public ImageView getDominantSpeakerImg() {
         return dominantSpeakerImg;
     }
+
+    public ImageView getNetworkQualityLevelImageView() { return networkQualityLevelImageView; }
 
     @Override
     protected void onFinishInflate() {

--- a/exampleMultipartyVideo/src/main/res/layout/activity_video.xml
+++ b/exampleMultipartyVideo/src/main/res/layout/activity_video.xml
@@ -54,14 +54,4 @@
 
     </LinearLayout>
 
-    <ImageView
-        android:id="@+id/local_network_quality_level"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/network_quality_level_0"
-        android:visibility="gone"
-        app:layout_constraintStart_toStartOf="parent"
-        android:contentDescription="@string/network_quality_level"
-        app:layout_constraintTop_toBottomOf="@id/videoStatusText"/>
-
 </android.support.constraint.ConstraintLayout>

--- a/exampleMultipartyVideo/src/main/res/layout/activity_video.xml
+++ b/exampleMultipartyVideo/src/main/res/layout/activity_video.xml
@@ -54,16 +54,6 @@
 
     </LinearLayout>
 
-    <TextView
-        android:id="@+id/videoStatusText"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:textColor="@android:color/black"
-        android:textSize="24sp"
-        android:text="@string/room_status"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
-
     <ImageView
         android:id="@+id/local_network_quality_level"
         android:layout_width="wrap_content"

--- a/exampleMultipartyVideo/src/main/res/layout/activity_video.xml
+++ b/exampleMultipartyVideo/src/main/res/layout/activity_video.xml
@@ -65,7 +65,7 @@
         app:layout_constraintTop_toTopOf="parent"/>
 
     <ImageView
-        android:id="@+id/network_quality_level"
+        android:id="@+id/local_network_quality_level"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:src="@drawable/network_quality_level_0"

--- a/exampleMultipartyVideo/src/main/res/layout/participant_container_layout.xml
+++ b/exampleMultipartyVideo/src/main/res/layout/participant_container_layout.xml
@@ -20,4 +20,17 @@
                 android:visibility="gone"
                 android:contentDescription="@string/dominant_speaker"
                 android:src="@drawable/ic_dominant_speaker_img" />
+
+            <ImageView
+                android:id="@+id/network_quality_level"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentStart="true"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentTop="true"
+                android:layout_margin="5dp"
+                android:visibility="gone"
+                android:contentDescription="@string/network_quality_level"
+                android:src="@drawable/network_quality_level_0" />
+
 </com.twilio.examplemultipartyvideo.ParticipantView>

--- a/exampleMultipartyVideo/src/main/res/values/strings.xml
+++ b/exampleMultipartyVideo/src/main/res/values/strings.xml
@@ -5,5 +5,4 @@
     <string name="switch_camera">Switch Camera</string>
     <string name="network_quality_level">Network Quality Level</string>
     <string name="dominant_speaker">Dominant Speaker</string>
-    <string name="connect_failed">Failed to connect</string>
 </resources>

--- a/exampleMultipartyVideo/src/main/res/values/strings.xml
+++ b/exampleMultipartyVideo/src/main/res/values/strings.xml
@@ -6,5 +6,4 @@
     <string name="network_quality_level">Network Quality Level</string>
     <string name="dominant_speaker">Dominant Speaker</string>
     <string name="connect_failed">Failed to connect</string>
-    <string name="room_status">Status:</string>
 </resources>

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -131,7 +131,6 @@ public class VideoActivity extends AppCompatActivity {
     /*
      * Android application UI elements
      */
-    private TextView videoStatusTextView;
     private CameraCapturerCompat cameraCapturerCompat;
     private LocalAudioTrack localAudioTrack;
     private LocalVideoTrack localVideoTrack;
@@ -161,7 +160,6 @@ public class VideoActivity extends AppCompatActivity {
 
         primaryVideoView = findViewById(R.id.primary_video_view);
         thumbnailVideoView = findViewById(R.id.thumbnail_video_view);
-        videoStatusTextView = findViewById(R.id.video_status_textview);
         reconnectingProgressBar = findViewById(R.id.reconnecting_progress_bar);
 
         connectActionFab = findViewById(R.id.connect_action_fab);
@@ -314,7 +312,6 @@ public class VideoActivity extends AppCompatActivity {
             reconnectingProgressBar.setVisibility((room.getState() != Room.State.RECONNECTING) ?
                     View.GONE :
                     View.VISIBLE);
-            videoStatusTextView.setText("Connected to " + room.getName());
         }
     }
 
@@ -585,7 +582,6 @@ public class VideoActivity extends AppCompatActivity {
             return;
         }
         remoteParticipantIdentity = remoteParticipant.getIdentity();
-        videoStatusTextView.setText("RemoteParticipant " + remoteParticipantIdentity + " joined");
 
         /*
          * Add remote participant renderer
@@ -633,8 +629,6 @@ public class VideoActivity extends AppCompatActivity {
      */
     @SuppressLint("SetTextI18n")
     private void removeRemoteParticipant(RemoteParticipant remoteParticipant) {
-        videoStatusTextView.setText("RemoteParticipant " + remoteParticipant.getIdentity() +
-                " left.");
         if (!remoteParticipant.getIdentity().equals(remoteParticipantIdentity)) {
             return;
         }
@@ -682,7 +676,6 @@ public class VideoActivity extends AppCompatActivity {
             @Override
             public void onConnected(Room room) {
                 localParticipant = room.getLocalParticipant();
-                videoStatusTextView.setText("Connected to " + room.getName());
                 setTitle(room.getName());
 
                 for (RemoteParticipant remoteParticipant : room.getRemoteParticipants()) {
@@ -693,19 +686,16 @@ public class VideoActivity extends AppCompatActivity {
 
             @Override
             public void onReconnecting(@NonNull Room room, @NonNull TwilioException twilioException) {
-                videoStatusTextView.setText("Reconnecting to " + room.getName());
                 reconnectingProgressBar.setVisibility(View.VISIBLE);
             }
 
             @Override
             public void onReconnected(@NonNull Room room) {
-                videoStatusTextView.setText("Connected to " + room.getName());
                 reconnectingProgressBar.setVisibility(View.GONE);
             }
 
             @Override
             public void onConnectFailure(Room room, TwilioException e) {
-                videoStatusTextView.setText("Failed to connect");
                 configureAudio(false);
                 intializeUI();
             }
@@ -713,7 +703,6 @@ public class VideoActivity extends AppCompatActivity {
             @Override
             public void onDisconnected(Room room, TwilioException e) {
                 localParticipant = null;
-                videoStatusTextView.setText("Disconnected from " + room.getName());
                 reconnectingProgressBar.setVisibility(View.GONE);
                 VideoActivity.this.room = null;
                 // Only reinitialize the UI if disconnect was not called from onDestroy()
@@ -770,7 +759,6 @@ public class VideoActivity extends AppCompatActivity {
                         remoteAudioTrackPublication.isTrackEnabled(),
                         remoteAudioTrackPublication.isTrackSubscribed(),
                         remoteAudioTrackPublication.getTrackName()));
-                videoStatusTextView.setText("onAudioTrackPublished");
             }
 
             @Override
@@ -785,7 +773,6 @@ public class VideoActivity extends AppCompatActivity {
                         remoteAudioTrackPublication.isTrackEnabled(),
                         remoteAudioTrackPublication.isTrackSubscribed(),
                         remoteAudioTrackPublication.getTrackName()));
-                videoStatusTextView.setText("onAudioTrackUnpublished");
             }
 
             @Override
@@ -800,7 +787,6 @@ public class VideoActivity extends AppCompatActivity {
                         remoteDataTrackPublication.isTrackEnabled(),
                         remoteDataTrackPublication.isTrackSubscribed(),
                         remoteDataTrackPublication.getTrackName()));
-                videoStatusTextView.setText("onDataTrackPublished");
             }
 
             @Override
@@ -815,7 +801,6 @@ public class VideoActivity extends AppCompatActivity {
                         remoteDataTrackPublication.isTrackEnabled(),
                         remoteDataTrackPublication.isTrackSubscribed(),
                         remoteDataTrackPublication.getTrackName()));
-                videoStatusTextView.setText("onDataTrackUnpublished");
             }
 
             @Override
@@ -830,7 +815,6 @@ public class VideoActivity extends AppCompatActivity {
                         remoteVideoTrackPublication.isTrackEnabled(),
                         remoteVideoTrackPublication.isTrackSubscribed(),
                         remoteVideoTrackPublication.getTrackName()));
-                videoStatusTextView.setText("onVideoTrackPublished");
             }
 
             @Override
@@ -845,7 +829,6 @@ public class VideoActivity extends AppCompatActivity {
                         remoteVideoTrackPublication.isTrackEnabled(),
                         remoteVideoTrackPublication.isTrackSubscribed(),
                         remoteVideoTrackPublication.getTrackName()));
-                videoStatusTextView.setText("onVideoTrackUnpublished");
             }
 
             @Override
@@ -859,7 +842,6 @@ public class VideoActivity extends AppCompatActivity {
                         remoteAudioTrack.isEnabled(),
                         remoteAudioTrack.isPlaybackEnabled(),
                         remoteAudioTrack.getName()));
-                videoStatusTextView.setText("onAudioTrackSubscribed");
             }
 
             @Override
@@ -873,7 +855,6 @@ public class VideoActivity extends AppCompatActivity {
                         remoteAudioTrack.isEnabled(),
                         remoteAudioTrack.isPlaybackEnabled(),
                         remoteAudioTrack.getName()));
-                videoStatusTextView.setText("onAudioTrackUnsubscribed");
             }
 
             @Override
@@ -889,7 +870,6 @@ public class VideoActivity extends AppCompatActivity {
                         remoteAudioTrackPublication.getTrackName(),
                         twilioException.getCode(),
                         twilioException.getMessage()));
-                videoStatusTextView.setText("onAudioTrackSubscriptionFailed");
             }
 
             @Override
@@ -902,7 +882,6 @@ public class VideoActivity extends AppCompatActivity {
                         remoteParticipant.getIdentity(),
                         remoteDataTrack.isEnabled(),
                         remoteDataTrack.getName()));
-                videoStatusTextView.setText("onDataTrackSubscribed");
             }
 
             @Override
@@ -915,7 +894,6 @@ public class VideoActivity extends AppCompatActivity {
                         remoteParticipant.getIdentity(),
                         remoteDataTrack.isEnabled(),
                         remoteDataTrack.getName()));
-                videoStatusTextView.setText("onDataTrackUnsubscribed");
             }
 
             @Override
@@ -931,7 +909,6 @@ public class VideoActivity extends AppCompatActivity {
                         remoteDataTrackPublication.getTrackName(),
                         twilioException.getCode(),
                         twilioException.getMessage()));
-                videoStatusTextView.setText("onDataTrackSubscriptionFailed");
             }
 
             @Override
@@ -944,7 +921,6 @@ public class VideoActivity extends AppCompatActivity {
                         remoteParticipant.getIdentity(),
                         remoteVideoTrack.isEnabled(),
                         remoteVideoTrack.getName()));
-                videoStatusTextView.setText("onVideoTrackSubscribed");
                 addRemoteParticipantVideo(remoteVideoTrack);
             }
 
@@ -958,7 +934,6 @@ public class VideoActivity extends AppCompatActivity {
                         remoteParticipant.getIdentity(),
                         remoteVideoTrack.isEnabled(),
                         remoteVideoTrack.getName()));
-                videoStatusTextView.setText("onVideoTrackUnsubscribed");
                 removeParticipantVideo(remoteVideoTrack);
             }
 
@@ -975,7 +950,6 @@ public class VideoActivity extends AppCompatActivity {
                         remoteVideoTrackPublication.getTrackName(),
                         twilioException.getCode(),
                         twilioException.getMessage()));
-                videoStatusTextView.setText("onVideoTrackSubscriptionFailed");
                 Snackbar.make(connectActionFab,
                         String.format("Failed to subscribe to %s video track",
                                 remoteParticipant.getIdentity()),


### PR DESCRIPTION
## Description

This PR adds Remote Participant Network Quality functionality to the Multiparty example application.

## Breakdown

- Consume Video Android 5.2.0
- Removed the status info text to be more consistent with iOS
- Added `networkQualityLevelImageView ` to `ParticipantView`
- Removed `networkQualityLevelImage` from `MultiPartyActivity` for the local participant in favor of using the one in the local participants `ParticipantView`
- Only show the network quality indicator when network quality levels are received for a participant to be consistent with the iOS app.
- Added nullability annotations to `RemoteParticipant.Listener`.
- Wired up the `RemoteParticipant.Listener.onNetworkQualityLevelChanged` for handling remote participant network quality events.

## Validation

- Testing across Pixel 3a, Pixel 2, iPhone X and iPhone Xs Max

![screenshot-1583441702847](https://user-images.githubusercontent.com/25950/76026375-a28adb00-5efc-11ea-9e12-5b729ec01888.jpg)

## Additional Notes

[Any additional comments, notes, or information relevant to reviewers.]

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
