### PR TITLE
Update SDK version to 5.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.8',
-            'videoAndroid': '5.2.0'
+            'videoAndroid': '5.3.0'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->


### PR DESCRIPTION
Update Version to latest release 5.3.0

### 5.3.0

* Programmable Video Android SDK 5.3.0 [[bintray]](https://bintray.com/twilio/releases/video-android/5.3.0), [[docs]](https://twilio.github.io/twilio-video-android/docs/5.3.0/)

Features

- Implemented a boolean Connect Option `enableIceGatheringOnAnyAddressPorts` that allows gathering of ICE candidates from "any address" ports. The default value is false. Setting it to true will allow applications to work in a wider set of VPN environments.

Bug Fixes

- Fixed a crash when attempting to unpublish a local track that was not previously published. [#447](https://github.com/twilio/video-quickstart-android/issues/447)

Known issues

- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. As a result, tracks published after a `Room.State.RECONNECTED` event might not be subscribed to by a `RemoteParticipant`.


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
