### PR TITLE
Update to Video Android 5.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
             'retrofit': '2.0.0-beta4',
             'okhttp': '3.6.0',
             'ion': '2.1.8',
-            'videoAndroid': '5.3.0'
+            'videoAndroid': '5.4.0'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->

--- a/exampleVideoInvite/src/main/res/layout/content_video.xml
+++ b/exampleVideoInvite/src/main/res/layout/content_video.xml
@@ -10,8 +10,8 @@
 
     <com.twilio.video.VideoView
         android:id="@+id/thumbnail_video_view"
-        app:overlaySurface="true"
-        app:mirror="true"
+        app:tviOverlaySurface="true"
+        app:tviMirror="true"
         android:visibility="gone"
         android:layout_width="96dp"
         android:layout_height="96dp"

--- a/quickstart/src/main/res/layout/content_video.xml
+++ b/quickstart/src/main/res/layout/content_video.xml
@@ -10,8 +10,8 @@
 
     <com.twilio.video.VideoView
         android:id="@+id/thumbnail_video_view"
-        app:overlaySurface="true"
-        app:mirror="true"
+        app:tviOverlaySurface="true"
+        app:tviMirror="true"
         android:visibility="gone"
         android:layout_width="96dp"
         android:layout_height="96dp"

--- a/quickstartKotlin/src/main/res/layout/content_video.xml
+++ b/quickstartKotlin/src/main/res/layout/content_video.xml
@@ -10,8 +10,8 @@
 
     <com.twilio.video.VideoView
         android:id="@+id/thumbnailVideoView"
-        app:overlaySurface="true"
-        app:mirror="true"
+        app:tviOverlaySurface="true"
+        app:tviMirror="true"
         android:visibility="gone"
         android:layout_width="96dp"
         android:layout_height="96dp"
@@ -20,7 +20,7 @@
 
     <com.twilio.video.VideoView
         android:id="@+id/primaryVideoView"
-        app:mirror="true"
+        app:tviMirror="true"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"/>


### PR DESCRIPTION
### 5.4.0

* Programmable Video Android SDK 5.4.0 [[bintray]](https://bintray.com/twilio/releases/video-android/5.4.0), [[docs]](https://twilio.github.io/twilio-video-android/docs/5.4.0/)

Enhancements

- Reduced the SDK size. The table below highlights the updated app size impact.

| ABI             | App Size Impact 5.3.0 | App Size Impact 5.4.0 |
| --- | --- | --- |
| universal       | 22.9MB | 21.8MB          |
| armeabi-v7a     | 5MB | 4.8MB           |
| arm64-v8a       | 5.9MB | 5.6MB           |
| x86             | 6.2MB | 6MB             |
| x86_64          | 6.4MB | 6MB             |

Bug Fixes

- Fixed [an issue](https://github.com/twilio/video-quickstart-android/issues/487) integrating the SDK with applications that contain an attribute of `scaleType`, `mirror`, or `overlaySurface`. These attributes defined for `VideoView` and `VideoTextureView` have been prefixed with `tvi` to prevent attribute name clashes. Reference the following snippets to update your application layout files.

    Configure video views before 5.4.0

    ```xml
    <com.twilio.video.VideoView
        app:overlaySurface="true"
        app:mirror="true"
        app:scaleType="fit"/>

    <com.twilio.video.VideoTextureView
        app:mirror="true"
        app:scaleType="fit"/>
    ```

    Configure video views in 5.4.0+

    ```xml
    <com.twilio.video.VideoView
        app:tviOverlaySurface="true"
        app:tviMirror="true"
        app:tviScaleType="fit"/>

    <com.twilio.video.VideoTextureView
        app:tviMirror="true"
        app:tviScaleType="fit"/>
    ```

Known issues

- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. As a result, tracks published after a `Room.State.RECONNECTED` event might not be subscribed to by a `RemoteParticipant`.

Size Report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| universal       | 21.8MB          |
| armeabi-v7a     | 4.8MB           |
| arm64-v8a       | 5.6MB           |
| x86             | 6MB             |
| x86_64          | 6MB             |
