### PR TITLE
Update to Video Android 5.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,20 +3,20 @@
 buildscript {
     ext.kotlin_version = '1.3.61'
     ext.versions = [
-            'java': JavaVersion.VERSION_1_8,
-            'androidGradlePlugin': '3.6.1',
-            'googleServices': '3.2.1',
-            'compileSdk': 29,
-            'buildTools': '28.0.3',
-            'minSdk': 16,
-            'targetSdk': 29,
-            'supportLibrary': '26.1.0',
-            'constraintLayout': '1.1.3',
-            'firebase': '10.0.1',
-            'retrofit': '2.0.0-beta4',
-            'okhttp': '3.6.0',
-            'ion': '2.1.8',
-            'videoAndroid': '5.4.0'
+            'java'               : JavaVersion.VERSION_1_8,
+            'androidGradlePlugin': '3.6.2',
+            'googleServices'     : '3.2.1',
+            'compileSdk'         : 29,
+            'buildTools'         : '28.0.3',
+            'minSdk'             : 16,
+            'targetSdk'          : 29,
+            'supportLibrary'     : '26.1.0',
+            'constraintLayout'   : '1.1.3',
+            'firebase'           : '10.0.1',
+            'retrofit'           : '2.0.0-beta4',
+            'okhttp'             : '3.6.0',
+            'ion'                : '2.1.8',
+            'videoAndroid'       : '5.5.0'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->


### PR DESCRIPTION
### 5.5.0

* Programmable Video Android SDK 5.5.0 [[bintray]](https://bintray.com/twilio/releases/video-android/5.5.0), [[docs]](https://twilio.github.io/twilio-video-android/docs/5.5.0/)

Enhancements

- Added `updateCaptureRequest` to `Camera2Capturer`. This API allows developers to update the [CaptureRequest](https://developer.android.com/reference/android/hardware/camera2/CaptureRequest) of an ongoing `Camera2Capturer` session. Reference the following snippet as an example of how to turn the flash on for the `Camera2Capturer`.

```
camera2Capturer.updateCaptureRequest(
        new CaptureRequestUpdater() {
            @Override
            public void apply(@NotNull CaptureRequest.Builder captureRequestBuilder) {
                captureRequestBuilder.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_TORCH);
            }
        });
```

Known issues

- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. As a result, tracks published after a `Room.State.RECONNECTED` event might not be subscribed to by a `RemoteParticipant`.

Size Report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| universal       | 21.8MB          |
| armeabi-v7a     | 4.8MB           |
| arm64-v8a       | 5.6MB           |
| x86             | 6MB             |
| x86_64          | 6MB             |
