### PR TITLE
Update to Video Android 5.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
             'retrofit'           : '2.0.0-beta4',
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
-            'videoAndroid'       : '5.5.0'
+            'videoAndroid'       : '5.5.1'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->


### PR DESCRIPTION
### 5.5.1

* Programmable Video Android SDK 5.5.1 [[bintray]](https://bintray.com/twilio/releases/video-android/5.5.1), [[docs]](https://twilio.github.io/twilio-video-android/docs/5.5.1/)

Bug Fixes

- Fixed an occasional native crash when disconnecting from a Room.
- Fixed a bug when establishing a signaling WebSocket that might cause only one address family (IPv4 or IPv6) to be tried.
- Publish stats reports every 10 seconds and active ICE candidate pair messages every 20 seconds. Previously both were reported every 4 seconds.

Known issues

- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. As a result, tracks published after a `Room.State.RECONNECTED` event might not be subscribed to by a `RemoteParticipant`.

Size Report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| universal       | 21.8MB          |
| armeabi-v7a     | 4.8MB           |
| arm64-v8a       | 5.6MB           |
| x86             | 6MB             |
| x86_64          | 6MB             |
