### PR TITLE
Update to Video Android 5.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
             'retrofit'           : '2.0.0-beta4',
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
-            'videoAndroid'       : '5.5.1'
+            'videoAndroid'       : '5.6.0'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->


### PR DESCRIPTION
### 5.6.0

* Programmable Video Android SDK 5.6.0 [[bintray]](https://bintray.com/twilio/releases/video-android/5.6.0), [[docs]](https://twilio.github.io/twilio-video-android/docs/5.6.0/)

Enhancements

- A subset of Android devices provide an [OpenSLES](href="https://www.khronos.org/opensles/) implementation. Although more efficient, the use of OpenSLES occasionally causes echo. As a result, the Video SDK now disables OpenSLES by default unless explicitly enabled. To enable OpenSLES, execute the following before invoking `Video.connect(...)` : `tvi.webrtc.voiceengine.WebRtcAudioManager.setBlacklistDeviceForOpenSLESUsage(false)`.

Known issues

- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. As a result, tracks published after a `Room.State.RECONNECTED` event might not be subscribed to by a `RemoteParticipant`.