### PR TITLE
Upgrade audioswitch to 0.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
             'videoAndroid'       : '5.6.0',
-            'audioSwitch'        : '0.1.2'
+            'audioSwitch'        : '0.1.3'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->


### PR DESCRIPTION
Upgraded audioswitch to 0.1.3

### 0.1.3

Bug Fixes

- Fixed crash by adding a default bluetooth device name.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
