### PR TITLE
Update to Video Android 5.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
             'retrofit'           : '2.0.0-beta4',
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
-            'videoAndroid'       : '5.6.0',
+            'videoAndroid'       : '5.7.0',
             'audioSwitch'        : '0.1.3'
     ]
 


### PR DESCRIPTION
### 5.7.0

* Programmable Video Android SDK 5.7.0 [[bintray]](https://bintray.com/twilio/releases/video-android/5.7.0), [[docs]](https://twilio.github.io/twilio-video-android/docs/5.7.0/)

Enhancements

- Previously, the Video Android SDK would fail connection attempts if the signaling server was busy with too many requests. Now, it will try again after a server specified backoff period either until it is successfully connected or the server asks it to stop trying. In this case, the `onConnectFailure` method is called with `SIGNALING_SERVER_BUSY_EXCEPTION`.

```.java
@Override
public void onConnectFailure(@NonNull Room room, @NonNull TwilioException twilioException) {
    if (twilioException.getCode() == TwilioException.SIGNALING_SERVER_BUSY_EXCEPTION) {
        Log.d("RoomListener", "Twilio's signaling server cannot accept connection requests at this time.");
    }
}
```

API Changes

- Added error code definitions:
    - `SIGNALING_SERVER_BUSY_EXCEPTION`
    - `ROOM_ACCOUNT_LIMIT_EXCEEDED_EXCEPTION`
    - `PARTICIPANT_ACCOUNT_LIMIT_EXCEEDED_EXCEPTION`
    - `PARTICIPANT_INVALID_SUBSCRIBE_RULE_EXCEPTION`
    - `TRACK_DATA_TRACK_MESSAGE_TOO_LARGE_EXCEPTION`
    - `TRACK_DATA_TRACK_SEND_BUFFER_FULL_EXCEPTION`
    - `MEDIA_DATA_TRACK_FAILED_EXCEPTION`
    - `MEDIA_DTLS_TRANSPORT_FAILED_EXCEPTION`
    - `MEDIA_ICE_RESTART_NOT_ALLOWED_EXCEPTION`

Known issues

- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. As a result, tracks published after a `Room.State.RECONNECTED` event might not be subscribed to by a `RemoteParticipant`.
