### PR TITLE
Update to Video Android 5.8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
             'retrofit'           : '2.0.0-beta4',
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
-            'videoAndroid'       : '5.7.0',
+            'videoAndroid'       : '5.8.0',
             'audioSwitch'        : '0.1.3'
     ]
 


### PR DESCRIPTION
### 5.8.0

* Programmable Video Android SDK 5.8.0 [[bintray]](https://bintray.com/twilio/releases/video-android/5.8.0), [[docs]](https://twilio.github.io/twilio-video-android/docs/5.8.0/)

## Features

### Bandwidth Profile

You can now configure how your available downlink bandwidth will be distributed among your subscribed RemoteVideoTracks by using a new optional ConnectOptions parameter bandwidthProfile. For more details and best practices, visit the [Network Bandwidth Profile API guide](https://www.twilio.com/docs/video/tutorials/using-bandwidth-profile-api). Here is a brief example:

```java
Room room = Video.connect(context, new ConnectOptions.Builder(accessToken)
                .bandwidthProfile(new BandwidthProfileOptions(new VideoBandwidthProfileOptions.Builder()
                         // Minimum subscribe priority of Dominant Speaker's RemoteVideoTracks
                        .dominantSpeakerPriority(TrackPriority.HIGH)
                         // Maximum bandwidth (Kbps) to be allocated to subscribed RemoteVideoTracks
                        .maxSubscriptionBitrate(150000L)
                        // Max number of visible RemoteVideoTracks. Other RemoteVideoTracks will be switched off
                        .maxTracks(3)
                        // Subscription mode: COLLABORATION, GRID, PRESENTATION
                        .mode(BandwidthProfileMode.COLLABORATION)
                        .renderDimensions(new HashMap<TrackPriority, VideoDimensions>(){{
                            // Desired render dimensions of RemoteVideoTracks with priority LOW.
                            put(TrackPriority.LOW, VideoDimensions.CIF_VIDEO_DIMENSIONS);

                            // Desired render dimensions of RemoteVideoTracks with priority STANDARD.
                            put(TrackPriority.STANDARD, VideoDimensions.VGA_VIDEO_DIMENSIONS);

                            // Desired render dimensions of RemoteVideoTracks with priority HIGH.
                            put(TrackPriority.HIGH, VideoDimensions.HD_720P_VIDEO_DIMENSIONS);
                        }})
                        // Track Switch Off mode: DETECTED, PREDICTED, DISABLED
                        .trackSwitchOffMode(TrackSwitchOffMode.DETECTED)
                        .build()))
                .build(),
        roomListener);
```

### Track Switch Off

As part of the Bandwidth Profile API, you can now specify the mode to control remote video track switch off behavior. The new `TrackSwitchOffMode` enum can be specified in the `VideoBandwidthProfileOptions` class and can be set to one of the following:

* `TrackSwitchOffMode.PREDICTED` - In this mode, `RemoteVideoTrack`s are pro-actively switched off when network congestion is predicted by the bandwidth estimation mechanism. This mode is used by default if not specified.
* `TrackSwitchOffMode.DETECTED` - In this mode, `RemoteVideoTrack`s are switched off only when network congestion is detected.
* `TrackSwitchOffMode.DISABLED` - In this mode, `RemoteVideoTrack`s will not be switched off. Instead tracks will be adjusted to lower quality.

Track switch off events are provided via two additional callbacks to `RemoteParticipant.Listener`.

```java
RemoteParticipant.Listener remoteParticipantListener = new RemoteParticipant.Listener() {
    ...

    @Override
    public void onVideoTrackSwitchedOff(
        @NonNull RemoteParticipant remoteParticipant,
        @NonNull RemoteVideoTrack remoteVideoTrack) {}

    @Override
    public void onVideoTrackSwitchedOn(
        @NonNull RemoteParticipant remoteParticipant,
        @NonNull RemoteVideoTrack remoteVideoTrack) {}
}
```

### Track Priority

While publishing a local track, you can now optionally specify its publish priority.

```java
/*
 * Publish a local track with high priority
 *
 * In addition, local track publications now contain a priority property which reflect the priority of
 * the published track.
 */
LocalTrackPublicationOptions localTrackPublicationOptions = new LocalTrackPublicationOptions(TrackPriority.HIGH);
localParticipant.publishTrack(localVideoTrack, localTrackPublicationOptions);

/*
 * The publish priority is also represented in remote audio, video, and data track publications.
 */
remoteVideoTrackPublication.getPublishPriority();
```

Also, the publisher's `TrackPriority` for the corresponding local Track can be updated after a
track has been published.

```java
localVideoTrackPublication.setPriority(TrackPriority.STANDARD);
```

When a `TrackPriority` is updated after the track has been published, remote participants will be alerted to the change via the `onAudioTrackPublishPriorityChanged()`, `onVideoTrackPublishPriorityChanged()` and `onDataTrackPublishPriorityChanged()` Listener methods.

Additionally, you can set a subscriber side priority for a `RemoteVideoTrack`.

```java
/*
 * Set a remote video track priority to HIGH. Note that this feature is only available
 * for RemoteVideoTrack.
 */
remoteVideoTrack.setPriority(TrackPriority.HIGH);

/*
 * Get the current remote video track priority.
 */
TrackPriority remoteVideoTrackPriority = remoteVideoTrack.getPriority();
```

This signals to the media server the relative importance of the track with respect to other tracks that may be shared to the `Room`. The media server takes this into account while allocating a subscribing `RemoteParticipant`'s bandwidth to the corresponding remote track. If you do not specify a priority, then it defaults to `TrackPriority.STANDARD`.

#### API Updates

- Added `TrackPriority` for track priorities of `Room`.
- Added a new class `LocalTrackPublicationOptions` to specify track publication options when publishing tracks via `LocalParticipant`.
- Added additional `LocalParticipant.publishTrack` methods that allow developers to specify `LocalTrackPublicationOptions`.
- Added a new `TrackPriority` property to `LocalAudioTrackPublication`, `LocalVideoTrackPublication`, and `LocalDataTrackPublication`.
- Added a new read-only property `publishPriority` of type `TrackPriority` to `RemoteAudioTrackPublication`, `RemoteVideoTrackPublication`, and `RemoteDataTrackPublication`. These read-only properties fetch the priorities at which the remote Audio, Video, and Data Tracks were published.
- Added the `RemoteParticipant.Listener.onAudioTrackPublishPriorityChanged()`, `RemoteParticipant.Listener.onVideTrackPublishPriorityChanged()` and `RemoteParticipant.Listener.onDataTrackPublishPriorityChanged()` methods.
- Changed the annotation of `LocalParticipant.getLocalAudioTracks`, `LocalParticipant.getLocalVideoTracks`, and `LocalParticipant.getLocalVideoTracks` from `@Nullable` to `@NonNull`. These methods were incorrectly annotated in a previous release.

Bug Fixes

 - Fixed a crash when the SDK was processing a local SDP that had incorrect number of SSRCs when applying VP8 simulcast.

Known issues

- Unpublishing and then republishing a `LocalVideoTrack` using VP8 simulcast does not complete. As a workaround, disable the Track instead.
- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. As a result, tracks published after a `Room.State.RECONNECTED` event might not be subscribed to by a `RemoteParticipant`.