### PR TITLE
Remove artifact desugaring flag

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,0 @@
-android.enableDexingArtifactTransform.desugaring=false


### PR DESCRIPTION
Remove `android.enableDexingArtifactTransform.desugaring=false` as there was a fix introduced in the Android Gradle Plugin version [3.6.0-beta05](https://issuetracker.google.com/issues/140508065#comment28) in which the flag is no longer needed.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
