### PR TITLE
Update to Video Android 5.8.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
     ext.versions = [
             'java'               : JavaVersion.VERSION_1_8,
-            'androidGradlePlugin': '3.6.3',
+            'androidGradlePlugin': '4.0.0',
             'googleServices'     : '3.2.1',
             'compileSdk'         : 29,
             'buildTools'         : '28.0.3',

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
             'retrofit'           : '2.0.0-beta4',
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
-            'videoAndroid'       : '5.8.0',
+            'videoAndroid'       : '5.8.1',
             'audioSwitch'        : '0.1.3'
     ]
 

--- a/exampleAdvancedCameraCapturer/gradle.properties
+++ b/exampleAdvancedCameraCapturer/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/exampleAudioSink/gradle.properties
+++ b/exampleAudioSink/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/exampleCustomVideoCapturer/gradle.properties
+++ b/exampleCustomVideoCapturer/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/exampleCustomVideoRenderer/gradle.properties
+++ b/exampleCustomVideoRenderer/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/exampleDataTrack/gradle.properties
+++ b/exampleDataTrack/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/exampleScreenCapturer/gradle.properties
+++ b/exampleScreenCapturer/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/exampleVideoInvite/gradle.properties
+++ b/exampleVideoInvite/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri May 01 11:22:36 CDT 2020
+#Tue Jun 16 17:23:01 EDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/quickstart/gradle.properties
+++ b/quickstart/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/quickstartKotlin/gradle.properties
+++ b/quickstartKotlin/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true


### PR DESCRIPTION
* Programmable Video Android SDK 5.8.1 [[bintray]](https://bintray.com/twilio/releases/video-android/5.8.1), [[docs]](https://twilio.github.io/twilio-video-android/docs/5.8.1/)

Bug Fixes

- Fixed the issue where unpublishing and then republishing a `LocalVideoTrack` using VP8 simulcast does not complete.

Maintenance

- Upgraded to Android Gradle Plugin 4.0.0 and Gradle 6.1.1
- Upgraded the SDK to use AndroidX. Please follow the [Migrating to AndroidX](https://developer.android.com/jetpack/androidx/migrate) instructions to consume Video Android 5.8.1 in your app.

Known issues

- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. As a result, tracks published after a `Room.State.RECONNECTED` event might not be subscribed to by a `RemoteParticipant`.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
