### PR TITLE
Update to Video Android 5.9.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
             'retrofit'           : '2.0.0-beta4',
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
-            'videoAndroid'       : '5.8.1',
+            'videoAndroid'       : '5.9.0',
             'audioSwitch'        : '0.1.4'
     ]
 


### PR DESCRIPTION
### 5.9.0

* Programmable Video Android SDK 5.9.0 [[bintray]](https://bintray.com/twilio/releases/video-android/5.9.0), [[docs]](https://twilio.github.io/twilio-video-android/docs/5.9.0/)

Enhancements

 - Reduced connection times by acquiring IceServers during the initial handshake with Twilio's signaling server rather than sending a request to a different endpoint
 - IceServers are now localized to your Participant's region rather than using Global Low Latency routing
 - The SDK no longer depends on `ecs.us1.twilio.com:443`

API Changes

- The following `IceOptions` properties are deprecated and setting them will have no effect.
    - `IceOptions.abortOnIceServersTimeout`
    - `IceOptions.iceServersTimeout`

Bug Fixes

- Fixed a bug where IceServers might not be fetched on a dual-stack device where the IPv6 network interface is not reachable. [CSDK-3295]
- Fixed a bug where passing in `IceTransportPolicy.RELAY` to the `IceOptions.Builder().iceTransportPolicy()` method was not being used. [GSDK-2148]

Known issues

- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. As a result, tracks published after a `Room.State.RECONNECTED` event might not be subscribed to by a `RemoteParticipant`.
