### PR TITLE
Update to Video Android 5.10.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
             'retrofit'           : '2.0.0-beta4',
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
-            'videoAndroid'       : '5.9.0',
+            'videoAndroid'       : '5.10.1',
             'audioSwitch'        : '0.1.5'
     ]
 


### PR DESCRIPTION
### 5.10.1

* Programmable Video Android SDK 5.10.1 [[bintray]](https://bintray.com/twilio/releases/video-android/5.10.1), [[docs]](https://twilio.github.io/twilio-video-android/docs/5.10.1/)

Bug Fixes

- Fixed a memory corruption crash that occurs when recovering from a media server failure in Group Rooms.

Known issues

- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. As a result, tracks published after a `Room.State.RECONNECTED` event might not be subscribed to by a `RemoteParticipant`.
