### PR TITLE
Upgrade to AudioSwitch 1.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ aliases:
     docker:
       - image: circleci/android:api-28-node
     environment:
-      - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+      - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport"
 
 jobs:
   setup-workspace:

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
             'videoAndroid'       : '5.10.1',
-            'audioSwitch'        : '0.1.5'
+            'audioSwitch'        : '1.0.0'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -2,7 +2,6 @@ package com.twilio.video.quickstart.activity;
 
 import android.Manifest;
 import android.annotation.SuppressLint;
-import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -27,12 +26,12 @@ import android.widget.ProgressBar;
 import android.widget.Toast;
 
 import com.koushikdutta.ion.Ion;
-import com.twilio.audioswitch.selection.AudioDevice;
-import com.twilio.audioswitch.selection.AudioDevice.BluetoothHeadset;
-import com.twilio.audioswitch.selection.AudioDevice.WiredHeadset;
-import com.twilio.audioswitch.selection.AudioDevice.Earpiece;
-import com.twilio.audioswitch.selection.AudioDevice.Speakerphone;
-import com.twilio.audioswitch.selection.AudioDeviceSelector;
+import com.twilio.audioswitch.AudioDevice;
+import com.twilio.audioswitch.AudioDevice.BluetoothHeadset;
+import com.twilio.audioswitch.AudioDevice.WiredHeadset;
+import com.twilio.audioswitch.AudioDevice.Earpiece;
+import com.twilio.audioswitch.AudioDevice.Speakerphone;
+import com.twilio.audioswitch.AudioSwitch;
 import com.twilio.video.AudioCodec;
 import com.twilio.video.CameraCapturer;
 import com.twilio.video.CameraCapturer.CameraSource;
@@ -148,7 +147,7 @@ public class VideoActivity extends AppCompatActivity {
     /*
      * Audio management
      */
-    private AudioDeviceSelector audioDeviceSelector;
+    private AudioSwitch audioSwitch;
     private int savedVolumeControlStream;
     private MenuItem audioDeviceMenuItem;
 
@@ -178,7 +177,7 @@ public class VideoActivity extends AppCompatActivity {
         /*
          * Setup audio management and set the volume control stream
          */
-        audioDeviceSelector = new AudioDeviceSelector(getApplicationContext());
+        audioSwitch = new AudioSwitch(getApplicationContext());
         savedVolumeControlStream = getVolumeControlStream();
         setVolumeControlStream(AudioManager.STREAM_VOICE_CALL);
 
@@ -208,7 +207,7 @@ public class VideoActivity extends AppCompatActivity {
          * Start the audio device selector after the menu is created and update the icon when the
          * selected audio device changes.
          */
-        audioDeviceSelector.start((audioDevices, audioDevice) -> {
+        audioSwitch.start((audioDevices, audioDevice) -> {
             updateAudioDeviceIcon(audioDevice);
             return Unit.INSTANCE;
         });
@@ -338,7 +337,7 @@ public class VideoActivity extends AppCompatActivity {
         /*
          * Tear down audio management and restore previous volume stream
          */
-        audioDeviceSelector.stop();
+        audioSwitch.stop();
         setVolumeControlStream(savedVolumeControlStream);
 
         /*
@@ -430,7 +429,7 @@ public class VideoActivity extends AppCompatActivity {
     }
 
     private void connectToRoom(String roomName) {
-        audioDeviceSelector.activate();
+        audioSwitch.activate();
         ConnectOptions.Builder connectOptionsBuilder = new ConnectOptions.Builder(accessToken)
                 .roomName(roomName);
 
@@ -493,8 +492,8 @@ public class VideoActivity extends AppCompatActivity {
      * Show the current available audio devices.
      */
     private void showAudioDevices() {
-        AudioDevice selectedDevice = audioDeviceSelector.getSelectedAudioDevice();
-        List<AudioDevice> availableAudioDevices = audioDeviceSelector.getAvailableAudioDevices();
+        AudioDevice selectedDevice = audioSwitch.getSelectedAudioDevice();
+        List<AudioDevice> availableAudioDevices = audioSwitch.getAvailableAudioDevices();
 
         if (selectedDevice != null) {
             int selectedDeviceIndex = availableAudioDevices.indexOf(selectedDevice);
@@ -513,7 +512,7 @@ public class VideoActivity extends AppCompatActivity {
                                 dialog.dismiss();
                                 AudioDevice selectedAudioDevice = availableAudioDevices.get(index);
                                 updateAudioDeviceIcon(selectedAudioDevice);
-                                audioDeviceSelector.selectDevice(selectedAudioDevice);
+                                audioSwitch.selectDevice(selectedAudioDevice);
                             }).create().show();
         }
     }
@@ -746,7 +745,7 @@ public class VideoActivity extends AppCompatActivity {
 
             @Override
             public void onConnectFailure(Room room, TwilioException e) {
-                audioDeviceSelector.deactivate();
+                audioSwitch.deactivate();
                 intializeUI();
             }
 
@@ -757,7 +756,7 @@ public class VideoActivity extends AppCompatActivity {
                 VideoActivity.this.room = null;
                 // Only reinitialize the UI if disconnect was not called from onDestroy()
                 if (!disconnectedFromOnDestroy) {
-                    audioDeviceSelector.deactivate();
+                    audioSwitch.deactivate();
                     intializeUI();
                     moveLocalVideoToPrimaryView();
                 }

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
@@ -21,12 +21,11 @@ import android.view.View
 import android.widget.EditText
 import android.widget.Toast
 import com.koushikdutta.ion.Ion
-import com.twilio.audioswitch.selection.AudioDevice
-import com.twilio.audioswitch.selection.AudioDevice.BluetoothHeadset
-import com.twilio.audioswitch.selection.AudioDevice.Earpiece
-import com.twilio.audioswitch.selection.AudioDevice.Speakerphone
-import com.twilio.audioswitch.selection.AudioDevice.WiredHeadset
-import com.twilio.audioswitch.selection.AudioDeviceSelector
+import com.twilio.audioswitch.AudioDevice
+import com.twilio.audioswitch.AudioDevice.BluetoothHeadset
+import com.twilio.audioswitch.AudioDevice.Speakerphone
+import com.twilio.audioswitch.AudioDevice.WiredHeadset
+import com.twilio.audioswitch.AudioSwitch
 import com.twilio.video.AudioCodec
 import com.twilio.video.CameraCapturer
 import com.twilio.video.ConnectOptions
@@ -168,7 +167,7 @@ class VideoActivity : AppCompatActivity() {
 
         override fun onConnectFailure(room: Room, e: TwilioException) {
             videoStatusTextView.text = "Failed to connect"
-            audioDeviceSelector.deactivate()
+            audioSwitch.deactivate()
             initializeUI()
         }
 
@@ -179,7 +178,7 @@ class VideoActivity : AppCompatActivity() {
             this@VideoActivity.room = null
             // Only reinitialize the UI if disconnect was not called from onDestroy()
             if (!disconnectedFromOnDestroy) {
-                audioDeviceSelector.deactivate()
+                audioSwitch.deactivate()
                 initializeUI()
                 moveLocalVideoToPrimaryView()
             }
@@ -414,8 +413,8 @@ class VideoActivity : AppCompatActivity() {
     /*
      * Audio management
      */
-    private val audioDeviceSelector by lazy {
-        AudioDeviceSelector(applicationContext)
+    private val audioSwitch by lazy {
+        AudioSwitch(applicationContext)
     }
     private var savedVolumeControlStream by Delegates.notNull<Int>()
     private lateinit var audioDeviceMenuItem: MenuItem
@@ -533,7 +532,7 @@ class VideoActivity : AppCompatActivity() {
         /*
          * Tear down audio management and restore previous volume stream
          */
-        audioDeviceSelector.stop()
+        audioSwitch.stop()
         volumeControlStream = savedVolumeControlStream
 
         /*
@@ -562,7 +561,7 @@ class VideoActivity : AppCompatActivity() {
          * Start the audio device selector after the menu is created and update the icon when the
          * selected audio device changes.
          */
-        audioDeviceSelector.start { audioDevices, audioDevice ->
+        audioSwitch.start { audioDevices, audioDevice ->
             updateAudioDeviceIcon(audioDevice)
         }
 
@@ -638,7 +637,7 @@ class VideoActivity : AppCompatActivity() {
     }
 
     private fun connectToRoom(roomName: String) {
-        audioDeviceSelector.activate();
+        audioSwitch.activate();
         val connectOptionsBuilder = ConnectOptions.Builder(accessToken)
                 .roomName(roomName)
 
@@ -696,9 +695,9 @@ class VideoActivity : AppCompatActivity() {
      * Show the current available audio devices.
      */
     private fun showAudioDevices() {
-        val availableAudioDevices = audioDeviceSelector.availableAudioDevices
+        val availableAudioDevices = audioSwitch.availableAudioDevices
 
-        audioDeviceSelector.selectedAudioDevice?.let { selectedDevice ->
+        audioSwitch.selectedAudioDevice?.let { selectedDevice ->
             val selectedDeviceIndex = availableAudioDevices.indexOf(selectedDevice)
             val audioDeviceNames = ArrayList<String>()
 
@@ -715,7 +714,7 @@ class VideoActivity : AppCompatActivity() {
                         dialog.dismiss()
                         val selectedAudioDevice = availableAudioDevices[index]
                         updateAudioDeviceIcon(selectedAudioDevice)
-                        audioDeviceSelector.selectDevice(selectedAudioDevice)
+                        audioSwitch.selectDevice(selectedAudioDevice)
                     }.create().show()
         }
     }


### PR DESCRIPTION
## AudioSwitch 1.0.0

Promotes 0.4.0 to the first stable release of this library.

## Java 11 Fix

`UseContainerSupport` is now used in place of the `UseCGroupMemoryLimitForHeap` JVM argument since it is no longer supported in the latest Java 11 docker image.

- [x] I acknowledge that all my contributions will be made under the project's license.
