### PR TITLE
Update to Video Android 5.10.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ aliases:
   - &configure-gradle
     name: Configure Gradle
     command: |
+      mkdir -p ~/.gradle
       echo "org.gradle.jvmargs=-Xmx4608m" >> ~/.gradle/gradle.properties
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,11 @@ aliases:
     environment:
       - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport"
 
+  - &configure-gradle
+    name: Configure Gradle
+    command: |
+      echo "org.gradle.jvmargs=-Xmx4608m" >> ~/.gradle/gradle.properties
+
 jobs:
   setup-workspace:
     <<: *build-defaults
@@ -86,36 +91,28 @@ jobs:
     <<: *build-defaults
     resource_class: large
     steps:
-      # Setup
       - checkout
       - attach_workspace:
           at: *workspace
       - restore-cache: *restore-cache-gradle
-
-      # Build app
+      - run: *configure-gradle
       - run:
           name: Build exampleAdvancedCameraCapturer
           command: ./gradlew -q exampleAdvancedCameraCapturer:assemble
-
-      # Save cache
       - save-cache: *save-cache-gradle
 
   build-exampleCustomVideoCapturer:
     <<: *build-defaults
     resource_class: large
     steps:
-      # Setup
       - checkout
       - attach_workspace:
           at: *workspace
       - restore-cache: *restore-cache-gradle
-
-      # Build app
+      - run: *configure-gradle
       - run:
           name: Build exampleCustomVideoCapturer
           command: ./gradlew -q exampleCustomVideoCapturer:assemble
-
-      # Save cache
       - save-cache: *save-cache-gradle
 
 
@@ -123,13 +120,11 @@ jobs:
     <<: *build-defaults
     resource_class: large
     steps:
-      # Setup
       - checkout
       - attach_workspace:
           at: *workspace
       - restore-cache: *restore-cache-gradle
-
-      # Build app
+      - run: *configure-gradle
       - run:
           name: Build exampleCustomVideoRenderer
           command: ./gradlew -q exampleCustomVideoRenderer:assemble
@@ -141,67 +136,53 @@ jobs:
     <<: *build-defaults
     resource_class: large
     steps:
-      # Setup
       - checkout
       - attach_workspace:
           at: *workspace
       - restore-cache: *restore-cache-gradle
-
-      # Build app
+      - run: *configure-gradle
       - run:
           name: Build exampleDataTrack
           command: ./gradlew -q exampleDataTrack:assemble
-
-      # Save cache
       - save-cache: *save-cache-gradle
 
   build-exampleAudioSink:
     <<: *build-defaults
     resource_class: large
     steps:
-      # Setup
       - checkout
       - attach_workspace:
           at: *workspace
       - restore-cache: *restore-cache-gradle
-
-      # Build app
+      - run: *configure-gradle
       - run:
           name: Build exampleDataTrack
           command: ./gradlew -q exampleAudioSink:assemble
-
-      # Save cache
       - save-cache: *save-cache-gradle
 
   build-exampleScreenCapturer:
     <<: *build-defaults
     resource_class: large
     steps:
-      # Setup
       - checkout
       - attach_workspace:
           at: *workspace
       - restore-cache: *restore-cache-gradle
-
-      # Build app
+      - run: *configure-gradle
       - run:
           name: Build exampleScreenCapturer
           command: ./gradlew -q exampleScreenCapturer:assemble
-
-      # Save cache
       - save-cache: *save-cache-gradle
 
   build-exampleVideoInvite:
     <<: *build-defaults
     resource_class: large
     steps:
-      # Setup
       - checkout
       - attach_workspace:
           at: *workspace
       - restore-cache: *restore-cache-gradle
-
-      # Build app
+      - run: *configure-gradle
       - run:
           name: Build exampleVideoInvite
           command: ./gradlew -q exampleVideoInvite:assemble
@@ -213,18 +194,14 @@ jobs:
     <<: *build-defaults
     resource_class: large
     steps:
-      # Setup
       - checkout
       - attach_workspace:
           at: *workspace
       - restore-cache: *restore-cache-gradle
-
-      # Build app
+      - run: *configure-gradle
       - run:
           name: Build quickstart
           command: ./gradlew -q quickstart:assemble
-
-      # Save cache
       - save-cache: *save-cache-gradle
 
 
@@ -232,13 +209,11 @@ jobs:
     <<: *build-defaults
     resource_class: large
     steps:
-      # Setup
       - checkout
       - attach_workspace:
           at: *workspace
       - restore-cache: *restore-cache-gradle
-
-      # Build app
+      - run: *configure-gradle
       - run:
           name: Build quickstartKotlin
           command: ./gradlew -q quickstartKotlin:assemble

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.4.0'
+    ext.kotlin_version = '1.3.61'
     ext.versions = [
             'java'               : JavaVersion.VERSION_1_8,
             'androidGradlePlugin': '4.0.1',

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,8 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
-    ext.kotlin_version = '1.3.61'
+    ext.kotlin_version = '1.4.0'
     ext.versions = [
             'java'               : JavaVersion.VERSION_1_8,
-            'androidGradlePlugin': '4.0.0',
+            'androidGradlePlugin': '4.0.1',
             'googleServices'     : '3.2.1',
             'compileSdk'         : 29,
             'buildTools'         : '28.0.3',
@@ -16,7 +14,7 @@ buildscript {
             'retrofit'           : '2.0.0-beta4',
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
-            'videoAndroid'       : '5.10.1',
+            'videoAndroid'       : '5.10.2',
             'audioSwitch'        : '1.0.0'
     ]
 

--- a/exampleVideoInvite/README.md
+++ b/exampleVideoInvite/README.md
@@ -57,9 +57,9 @@ the Notify Service make sure you select the FCM credential that you created in t
 
 ### <a name="bullet4"></a>4. Start the SDK Starter project
 
-Type `source .env; node .`
+Type `source .env; java -jar target/sdk-starter-1.0-SNAPSHOT.jar`
 
-Using ngrok type `ngrok http 3000`
+Using ngrok type `ngrok http 4567`
 
 ### <a name="bullet5"></a>5. Run the application
 

--- a/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/notify/api/TwilioSDKStarterAPI.java
+++ b/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/notify/api/TwilioSDKStarterAPI.java
@@ -12,6 +12,7 @@ import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
+import retrofit2.http.Headers;
 import retrofit2.http.POST;
 
 import static com.twilio.video.examples.videoinvite.VideoInviteActivity.TWILIO_SDK_STARTER_SERVER_URL;
@@ -27,12 +28,15 @@ public class TwilioSDKStarterAPI {
         @GET("/token")
         Call<Token> fetchToken();
         // Fetch an access token with a specific identity
+        @Headers("Content-Type: application/json")
         @POST("/token")
         Call<Token> fetchToken(@Body Identity identity);
         // Register this binding with Twilio Notify
+        @Headers("Content-Type: application/json")
         @POST("/register")
         Call<Void> register(@Body Binding binding);
         // Send notifications to Twilio Notify registrants
+        @Headers("Content-Type: application/json")
         @POST("/send-notification")
         Call<Void> sendNotification(@Body Notification notification);
     }


### PR DESCRIPTION
* Programmable Video Android SDK 5.10.2 [[bintray]](https://bintray.com/twilio/releases/video-android/5.10.2), [[docs]](https://twilio.github.io/twilio-video-android/docs/5.10.2/)

Bug Fixes

- Fixed a bug on devices with more than two cameras where after `CameraCapturer.switchCamera(...)` completes, `CameraCapturer.getCameraSource()` would return an incorrect value. [#548](https://github.com/twilio/video-quickstart-android/issues/548)

Known issues

- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. As a result, tracks published after a `Room.State.RECONNECTED` event might not be subscribed to by a `RemoteParticipant`.



Size Report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| x86             | 6MB             |
| x86_64          | 6.1MB           |
| armeabi-v7a     | 4.8MB           |
| arm64-v8a       | 5.7MB           |
| universal       | 21.9MB          |
