### PR TITLE
Update to Video Android 5.11.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
             'retrofit'           : '2.0.0-beta4',
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
-            'videoAndroid'       : '5.10.2',
+            'videoAndroid'       : '5.11.0',
             'audioSwitch'        : '1.0.0'
     ]
 


### PR DESCRIPTION
* Programmable Video Android SDK 5.11.0 [[bintray]](https://bintray.com/twilio/releases/video-android/5.11.0), [[docs]](https://twilio.github.io/twilio-video-android/docs/5.11.0/)

Bug Fixes

- Set the default values of `AudioOptions` properties to match the default WebRTC values.

Known issues

- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. As a result, tracks published after a `Room.State.RECONNECTED` event might not be subscribed to by a `RemoteParticipant`.



Size Report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| x86             | 6MB             |
| x86_64          | 6.1MB           |
| armeabi-v7a     | 4.8MB           |
| arm64-v8a       | 5.7MB           |
| universal       | 21.9MB          |