### PR TITLE
Upgrade AudioSwitch to 1.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
             'videoAndroid'       : '5.11.0',
-            'audioSwitch'        : '1.0.0'
+            'audioSwitch'        : '1.0.1'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->


### PR DESCRIPTION
## AudioSwitch 1.0.1

Enhancements

- Upgraded Kotlin to `1.4.0`.
- Improved the Bluetooth headset connection and audio change reliability by registering the `BluetoothHeadset.ACTION_CONNECTION_STATE_CHANGED` and `BluetoothHeadset.ACTION_AUDIO_STATE_CHANGED` intent actions instead of relying on `android.bluetooth.BluetoothDevice` and `android.media.AudioManager` intent actions.
- The context provided when constructing `AudioSwitch` can now take any context. Previously the `ApplicationContext` was required.

Bug Fixes

- Added the internal access modifier to the `SystemClockWrapper` class since it is not meant to be exposed publicly.

## Validation

- Passed CI.
- Manually validated on a Huawei P30 Lite.

- [x] I acknowledge that all my contributions will be made under the project's license.
