### PR TITLE
Update to Video Android 5.11.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
             'retrofit'           : '2.0.0-beta4',
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
-            'videoAndroid'       : '5.11.0',
+            'videoAndroid'       : '5.11.1',
             'audioSwitch'        : '1.0.1'
     ]
 


### PR DESCRIPTION
# 5.11.1

* Programmable Video Android SDK 5.11.1 [[bintray]](https://bintray.com/twilio/releases/video-android/5.11.1), [[docs]](https://twilio.github.io/twilio-video-android/docs/5.11.1/)

Bug Fixes

- Fixed an SCTP related WebRTC security vulnerability detailed [here](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-6514).

Known issues

- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. As a result, tracks published after a `Room.State.RECONNECTED` event might not be subscribed to by a `RemoteParticipant`.




Size Report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| x86             | 6MB             |
| x86_64          | 6.1MB           |
| armeabi-v7a     | 4.8MB           |
| arm64-v8a       | 5.7MB           |
| universal       | 22MB            |


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
