### PR TITLE
Upgrade AudioSwitch to 1.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
             'videoAndroid'       : '5.12.0',
-            'audioSwitch'        : '1.0.1'
+            'audioSwitch'        : '1.1.0'
     ]
 
     ext.getSecretProperty = { key, defaultValue ->

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
@@ -23,6 +23,7 @@ import android.widget.Toast
 import com.koushikdutta.ion.Ion
 import com.twilio.audioswitch.AudioDevice
 import com.twilio.audioswitch.AudioDevice.BluetoothHeadset
+import com.twilio.audioswitch.AudioDevice.Earpiece
 import com.twilio.audioswitch.AudioDevice.Speakerphone
 import com.twilio.audioswitch.AudioDevice.WiredHeadset
 import com.twilio.audioswitch.AudioSwitch
@@ -414,7 +415,8 @@ class VideoActivity : AppCompatActivity() {
      * Audio management
      */
     private val audioSwitch by lazy {
-        AudioSwitch(applicationContext)
+        AudioSwitch(applicationContext, preferredDeviceList = listOf(BluetoothHeadset::class.java,
+                WiredHeadset::class.java, Speakerphone::class.java, Earpiece::class.java))
     }
     private var savedVolumeControlStream by Delegates.notNull<Int>()
     private lateinit var audioDeviceMenuItem: MenuItem


### PR DESCRIPTION
### 1.1.0

Enhancements

- Added a constructor parameter named `preferredDeviceList` to configure the order in which audio devices are automatically selected and activated when `selectedAudioDevice` is null.
```kotlin
val audioSwitch = AudioSwitch(application, preferredDeviceList = listOf(Speakerphone::class.java, BluetoothHeadset::class.java))
```
- Updated `compileSdkVersion` and `targetSdkVersion` to Android API version `30`.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
