### PR TITLE
Update to 5.13.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
             'retrofit'           : '2.0.0-beta4',
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
-            'videoAndroid'       : '5.12.0',
+            'videoAndroid'       : '5.13.0',
             'audioSwitch'        : '1.1.0'
     ]
 


### PR DESCRIPTION
* Programmable Video Android SDK 5.13.0 [[bintray]](https://bintray.com/twilio/releases/video-android/5.13.0), [[docs]](https://twilio.github.io/twilio-video-android/docs/5.13.0/)

Maintenance

- Added `VideoCapturer#setSurfaceTextureHelper`. This method enables SDK provided video capturers to capture to a surface texture using a public API rather than an internal method. While this method is public, capturing to a surface texture is currently only supported with `Camera2Capturer`, and `ScreenCapturer`. Capturing to a surface texture will be enabled in a future release.

Bug Fixes

- Fixed a race condition that could cause a crash or unnecessary web socket signaling reconnection.
- Fixed a bug where private IP address was not masked properly while publishing insights event.

Known issues

- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. As a result, tracks published after a `Room.State.RECONNECTED` event might not be subscribed to by a `RemoteParticipant`.



Size Report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| x86             | 6MB             |
| x86_64          | 6.1MB           |
| armeabi-v7a     | 4.8MB           |
| arm64-v8a       | 5.7MB           |
| universal       | 22MB            |
