### PR TITLE
Update to 6.0.0-preview3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
             'retrofit'           : '2.0.0-beta4',
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
-            'videoAndroid'       : '6.0.0-preview2',
+            'videoAndroid'       : '6.0.0-preview3',
             'audioSwitch'        : '1.1.0'
     ]
 

--- a/exampleAdvancedCameraCapturer/src/main/java/com/twilio/video/examples/advancedcameracapturer/AdvancedCameraCapturerActivity.kt
+++ b/exampleAdvancedCameraCapturer/src/main/java/com/twilio/video/examples/advancedcameracapturer/AdvancedCameraCapturerActivity.kt
@@ -18,6 +18,7 @@ import com.twilio.video.CameraCapturer
 import com.twilio.video.CameraParameterUpdater
 import com.twilio.video.LocalVideoTrack
 import com.twilio.video.VideoView
+import tvi.webrtc.Camera1Enumerator
 
 /**
  * This example demonstrates advanced use cases of [com.twilio.video.CameraCapturer]. Current
@@ -33,8 +34,13 @@ class AdvancedCameraCapturerActivity : Activity() {
     private lateinit var pictureImageView: ImageView
     private lateinit var pictureDialog: AlertDialog
 
+    private val backCameraId by lazy {
+        val camera1Enumerator = Camera1Enumerator()
+        val cameraId = camera1Enumerator.deviceNames.find { camera1Enumerator.isBackFacing(it) }
+        requireNotNull(cameraId)
+    }
     private val cameraCapturer by lazy {
-        CameraCapturer(this, CameraCapturer.CameraSource.BACK_CAMERA)
+        CameraCapturer(this, backCameraId)
     }
     private val localVideoTrack by lazy {
         LocalVideoTrack.create(this, true, cameraCapturer)

--- a/exampleCustomVideoSink/src/main/java/com/twilio/video/examples/customvideosink/CustomVideoSinkVideoActivity.kt
+++ b/exampleCustomVideoSink/src/main/java/com/twilio/video/examples/customvideosink/CustomVideoSinkVideoActivity.kt
@@ -13,6 +13,7 @@ import android.widget.Toast
 import com.twilio.video.CameraCapturer
 import com.twilio.video.LocalVideoTrack
 import com.twilio.video.VideoView
+import tvi.webrtc.Camera1Enumerator
 
 /**
  * This example demonstrates how to implement a custom renderer. Here we render the contents
@@ -26,11 +27,16 @@ class CustomVideoSinkVideoActivity : Activity() {
     private val snapshotVideoRenderer by lazy {
         SnapshotVideoSink(snapshotImageView)
     }
+    private val frontCameraId by lazy {
+        val camera1Enumerator = Camera1Enumerator()
+        val cameraId = camera1Enumerator.deviceNames.find { camera1Enumerator.isFrontFacing(it) }
+        requireNotNull(cameraId)
+    }
     private val localVideoTrack by lazy {
         LocalVideoTrack.create(
             this, true, CameraCapturer(
                 this,
-                CameraCapturer.CameraSource.FRONT_CAMERA, null
+                frontCameraId, null
             )
         )
     }

--- a/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
+++ b/exampleVideoInvite/src/main/java/com/twilio/video/examples/videoinvite/VideoInviteActivity.java
@@ -490,7 +490,7 @@ public class VideoInviteActivity extends AppCompatActivity {
     }
 
     private String getFrontCameraId() {
-        if (frontCameraId != null) {
+        if (frontCameraId == null) {
             for (String deviceName : camera1Enumerator.getDeviceNames()) {
                 if (camera1Enumerator.isFrontFacing(deviceName)) {
                     frontCameraId = deviceName;
@@ -502,7 +502,7 @@ public class VideoInviteActivity extends AppCompatActivity {
     }
 
     private String getBackCameraId() {
-        if (backCameraId != null) {
+        if (backCameraId == null) {
             for (String deviceName : camera1Enumerator.getDeviceNames()) {
                 if (camera1Enumerator.isBackFacing(deviceName)) {
                     backCameraId = deviceName;

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -34,7 +34,6 @@ import com.twilio.audioswitch.AudioDevice.Speakerphone;
 import com.twilio.audioswitch.AudioSwitch;
 import com.twilio.video.AudioCodec;
 import com.twilio.video.CameraCapturer;
-import com.twilio.video.CameraCapturer.CameraSource;
 import com.twilio.video.ConnectOptions;
 import com.twilio.video.EncodingParameters;
 import com.twilio.video.G722Codec;
@@ -276,7 +275,7 @@ public class VideoActivity extends AppCompatActivity {
         if (localVideoTrack == null && checkPermissionForCameraAndMicrophone()) {
             localVideoTrack = LocalVideoTrack.create(this,
                     true,
-                    cameraCapturerCompat.getVideoCapturer(),
+                    cameraCapturerCompat,
                     LOCAL_VIDEO_TRACK_NAME);
             localVideoTrack.addSink(localVideoView);
 
@@ -392,20 +391,14 @@ public class VideoActivity extends AppCompatActivity {
         localAudioTrack = LocalAudioTrack.create(this, true, LOCAL_AUDIO_TRACK_NAME);
 
         // Share your camera
-        cameraCapturerCompat = new CameraCapturerCompat(this, getAvailableCameraSource());
+        cameraCapturerCompat = new CameraCapturerCompat(this, CameraCapturerCompat.Source.FRONT_CAMERA);
         localVideoTrack = LocalVideoTrack.create(this,
                 true,
-                cameraCapturerCompat.getVideoCapturer(),
+                cameraCapturerCompat,
                 LOCAL_VIDEO_TRACK_NAME);
         primaryVideoView.setMirror(true);
         localVideoTrack.addSink(primaryVideoView);
         localVideoView = primaryVideoView;
-    }
-
-    private CameraSource getAvailableCameraSource() {
-        return (CameraCapturer.isSourceAvailable(CameraSource.FRONT_CAMERA)) ?
-                (CameraSource.FRONT_CAMERA) :
-                (CameraSource.BACK_CAMERA);
     }
 
     private void setAccessToken() {
@@ -669,7 +662,7 @@ public class VideoActivity extends AppCompatActivity {
             localVideoTrack.addSink(thumbnailVideoView);
             localVideoView = thumbnailVideoView;
             thumbnailVideoView.setMirror(cameraCapturerCompat.getCameraSource() ==
-                    CameraSource.FRONT_CAMERA);
+                    CameraCapturerCompat.Source.FRONT_CAMERA);
         }
     }
 
@@ -712,7 +705,7 @@ public class VideoActivity extends AppCompatActivity {
             }
             localVideoView = primaryVideoView;
             primaryVideoView.setMirror(cameraCapturerCompat.getCameraSource() ==
-                    CameraSource.FRONT_CAMERA);
+                    CameraCapturerCompat.Source.FRONT_CAMERA);
         }
     }
 
@@ -1067,12 +1060,12 @@ public class VideoActivity extends AppCompatActivity {
     private View.OnClickListener switchCameraClickListener() {
         return v -> {
             if (cameraCapturerCompat != null) {
-                CameraSource cameraSource = cameraCapturerCompat.getCameraSource();
+                CameraCapturerCompat.Source cameraSource = cameraCapturerCompat.getCameraSource();
                 cameraCapturerCompat.switchCamera();
                 if (thumbnailVideoView.getVisibility() == View.VISIBLE) {
-                    thumbnailVideoView.setMirror(cameraSource == CameraSource.BACK_CAMERA);
+                    thumbnailVideoView.setMirror(cameraSource == CameraCapturerCompat.Source.BACK_CAMERA);
                 } else {
-                    primaryVideoView.setMirror(cameraSource == CameraSource.BACK_CAMERA);
+                    primaryVideoView.setMirror(cameraSource == CameraCapturerCompat.Source.BACK_CAMERA);
                 }
             }
         };

--- a/quickstart/src/main/java/com/twilio/video/quickstart/util/CameraCapturerCompat.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/util/CameraCapturerCompat.java
@@ -7,94 +7,98 @@ import android.hardware.camera2.CameraManager;
 import android.hardware.camera2.CameraMetadata;
 import android.hardware.camera2.params.StreamConfigurationMap;
 import android.os.Build;
-import android.support.annotation.NonNull;
-import android.support.annotation.RequiresApi;
-import android.util.Log;
-import android.util.Pair;
-
+import androidx.annotation.RequiresApi;
 import com.twilio.video.Camera2Capturer;
 import com.twilio.video.CameraCapturer;
 import com.twilio.video.VideoCapturer;
-
+import java.util.HashMap;
+import java.util.Map;
+import tvi.webrtc.Camera1Enumerator;
 import tvi.webrtc.Camera2Enumerator;
+import tvi.webrtc.CapturerObserver;
+import tvi.webrtc.SurfaceTextureHelper;
 
 /*
  * Simple wrapper class that uses Camera2Capturer with supported devices.
  */
-public class CameraCapturerCompat {
-    private static final String TAG = "CameraCapturerCompat";
-
-    private CameraCapturer camera1Capturer;
-    private Camera2Capturer camera2Capturer;
-    private Pair<CameraCapturer.CameraSource, String> frontCameraPair;
-    private Pair<CameraCapturer.CameraSource, String> backCameraPair;
+public class CameraCapturerCompat implements VideoCapturer {
+    private final CameraCapturer camera1Capturer;
+    private final Camera2Capturer camera2Capturer;
+    private final VideoCapturer activeCapturer;
+    private final Map<Source, String> camera1IdMap = new HashMap<>();
+    private final Map<String, Source> camera1SourceMap = new HashMap<>();
+    private final Map<Source, String> camera2IdMap = new HashMap<>();
+    private final Map<String, Source> camera2SourceMap = new HashMap<>();
     private CameraManager cameraManager;
 
-    public CameraCapturerCompat(Context context, CameraCapturer.CameraSource cameraSource) {
+    public enum Source {
+        FRONT_CAMERA,
+        BACK_CAMERA
+    }
+
+    public CameraCapturerCompat(Context context, Source cameraSource) {
         if (Camera2Capturer.isSupported(context) && isLollipopApiSupported()) {
             cameraManager = (CameraManager) context.getSystemService(Context.CAMERA_SERVICE);
-            setCameraPairs(context);
-            Camera2Capturer.Listener camera2Listener =
-                    new Camera2Capturer.Listener() {
-                        @Override
-                        public void onFirstFrameAvailable() {
-                            Log.i(TAG,"onFirstFrameAvailable");
-                        }
-
-                        @Override
-                        public void onCameraSwitched(@NonNull String newCameraId) {
-                            Log.i(TAG, "onCameraSwitched: newCameraId = " + newCameraId);
-                        }
-
-                        @Override
-                        public void onError(
-                                @NonNull Camera2Capturer.Exception camera2CapturerException) {
-                            Log.e(TAG, camera2CapturerException.toString());
-                        }
-                    };
-            camera2Capturer =
-                    new Camera2Capturer(context, getCameraId(cameraSource), camera2Listener);
+            setCamera2Maps(context);
+            camera2Capturer = new Camera2Capturer(context, camera2IdMap.get(cameraSource));
+            activeCapturer = camera2Capturer;
+            camera1Capturer = null;
         } else {
-            camera1Capturer = new CameraCapturer(context, cameraSource);
+            setCamera1Maps();
+            camera1Capturer = new CameraCapturer(context, camera1IdMap.get(cameraSource));
+            activeCapturer = camera1Capturer;
+            camera2Capturer = null;
         }
     }
 
-    public CameraCapturer.CameraSource getCameraSource() {
+    public Source getCameraSource() {
         if (usingCamera1()) {
-            return camera1Capturer.getCameraSource();
+            return camera1SourceMap.get(camera1Capturer.getCameraId());
         } else {
-            return getCameraSource(camera2Capturer.getCameraId());
+            return camera2SourceMap.get(camera2Capturer.getCameraId());
         }
+    }
+
+    @Override
+    public void initialize(
+            SurfaceTextureHelper surfaceTextureHelper,
+            Context context,
+            CapturerObserver capturerObserver) {
+        activeCapturer.initialize(surfaceTextureHelper, context, capturerObserver);
+    }
+
+    @Override
+    public void startCapture(int width, int height, int framerate) {
+        activeCapturer.startCapture(width, height, framerate);
+    }
+
+    @Override
+    public void stopCapture() throws InterruptedException {
+        activeCapturer.stopCapture();
+    }
+
+    @Override
+    public boolean isScreencast() {
+        return activeCapturer.isScreencast();
+    }
+
+    @Override
+    public void dispose() {
+        activeCapturer.dispose();
     }
 
     public void switchCamera() {
-        if (usingCamera1()) {
-            camera1Capturer.switchCamera();
-        } else {
-            CameraCapturer.CameraSource cameraSource =
-                    getCameraSource(camera2Capturer.getCameraId());
+        Source cameraSource = getCameraSource();
+        Map<Source, String> idMap = usingCamera1() ? camera1IdMap : camera2IdMap;
+        String newCameraId =
+                cameraSource == Source.FRONT_CAMERA
+                        ? idMap.get(Source.BACK_CAMERA)
+                        : idMap.get(Source.FRONT_CAMERA);
 
-            if (cameraSource == CameraCapturer.CameraSource.FRONT_CAMERA) {
-                camera2Capturer.switchCamera(backCameraPair.second);
-            } else {
-                camera2Capturer.switchCamera(frontCameraPair.second);
-            }
-        }
-    }
-
-    /*
-     * This method is required because this class is not an implementation of VideoCapturer due to
-     * a shortcoming in VideoCapturerDelegate where only instances of CameraCapturer,
-     * Camera2Capturer, and ScreenCapturer are initialized correctly with a SurfaceTextureHelper.
-     * Because capturing to a texture is not a part of the official public API we must expose
-     * this method instead of writing a custom capturer so that camera capturers are properly
-     * initialized.
-     */
-    public VideoCapturer getVideoCapturer() {
         if (usingCamera1()) {
-            return camera1Capturer;
+            camera1Capturer.switchCamera(newCameraId);
         } else {
-            return camera2Capturer;
+            camera2Capturer.switchCamera(newCameraId);
         }
     }
 
@@ -103,34 +107,33 @@ public class CameraCapturerCompat {
     }
 
     @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    private void setCameraPairs(Context context) {
+    private void setCamera2Maps(Context context) {
         Camera2Enumerator camera2Enumerator = new Camera2Enumerator(context);
         for (String cameraId : camera2Enumerator.getDeviceNames()) {
             if (isCameraIdSupported(cameraId)) {
                 if (camera2Enumerator.isFrontFacing(cameraId)) {
-                    frontCameraPair =
-                            new Pair<>(CameraCapturer.CameraSource.FRONT_CAMERA, cameraId);
+                    camera2IdMap.put(Source.FRONT_CAMERA, cameraId);
+                    camera2SourceMap.put(cameraId, Source.FRONT_CAMERA);
                 }
                 if (camera2Enumerator.isBackFacing(cameraId)) {
-                    backCameraPair = new Pair<>(CameraCapturer.CameraSource.BACK_CAMERA, cameraId);
+                    camera2IdMap.put(Source.BACK_CAMERA, cameraId);
+                    camera2SourceMap.put(cameraId, Source.BACK_CAMERA);
                 }
             }
         }
     }
 
-    private String getCameraId(CameraCapturer.CameraSource cameraSource) {
-        if (frontCameraPair.first == cameraSource) {
-            return frontCameraPair.second;
-        } else {
-            return backCameraPair.second;
-        }
-    }
-
-    private CameraCapturer.CameraSource getCameraSource(String cameraId) {
-        if (frontCameraPair.second.equals(cameraId)) {
-            return frontCameraPair.first;
-        } else {
-            return backCameraPair.first;
+    private void setCamera1Maps() {
+        Camera1Enumerator camera1Enumerator = new Camera1Enumerator();
+        for (String deviceName : camera1Enumerator.getDeviceNames()) {
+            if (camera1Enumerator.isFrontFacing(deviceName)) {
+                camera1IdMap.put(Source.FRONT_CAMERA, deviceName);
+                camera1SourceMap.put(deviceName, Source.FRONT_CAMERA);
+            }
+            if (camera1Enumerator.isBackFacing(deviceName)) {
+                camera1IdMap.put(Source.BACK_CAMERA, deviceName);
+                camera1SourceMap.put(deviceName, Source.BACK_CAMERA);
+            }
         }
     }
 
@@ -169,10 +172,8 @@ public class CameraCapturerCompat {
         Integer colorFilterArrangement =
                 cameraCharacteristics.get(
                         CameraCharacteristics.SENSOR_INFO_COLOR_FILTER_ARRANGEMENT);
-        // Normalize the color filter arrangement
-        colorFilterArrangement = colorFilterArrangement == null ? -1 : colorFilterArrangement;
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && colorFilterArrangement != null) {
             isMonoChromeSupported =
                     colorFilterArrangement
                             == CameraMetadata.SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_MONO

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/CameraCapturerCompat.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/CameraCapturerCompat.kt
@@ -2,87 +2,84 @@ package com.twilio.video.quickstart.kotlin
 
 import android.content.Context
 import android.graphics.ImageFormat
-import android.hardware.camera2.CameraAccessException
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager
 import android.hardware.camera2.CameraMetadata
 import android.os.Build
-import android.support.annotation.RequiresApi
-import android.util.Log
-import android.util.Pair
+import androidx.annotation.RequiresApi
 import com.twilio.video.Camera2Capturer
 import com.twilio.video.CameraCapturer
 import com.twilio.video.VideoCapturer
+import tvi.webrtc.Camera1Enumerator
 import tvi.webrtc.Camera2Enumerator
+import tvi.webrtc.CapturerObserver
+import tvi.webrtc.SurfaceTextureHelper
+import java.util.*
 
-class CameraCapturerCompat(context: Context, cameraSource: CameraCapturer.CameraSource) {
-    private val TAG = "CameraCapturerCompat"
-
-    private var camera1Capturer: CameraCapturer? = null
-    private var camera2Capturer: Camera2Capturer? = null
-    private var frontCameraPair: Pair<CameraCapturer.CameraSource, String>? = null
-    private var backCameraPair: Pair<CameraCapturer.CameraSource, String>? = null
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+/*
+ * Simple wrapper class that uses Camera2Capturer with supported devices.
+ */
+class CameraCapturerCompat(context: Context, cameraSource: Source) : VideoCapturer {
+    private val camera1Capturer: CameraCapturer?
+    private val camera2Capturer: Camera2Capturer?
+    private val activeCapturer: VideoCapturer
+    private val camera1IdMap: MutableMap<Source, String> = EnumMap(Source::class.java)
+    private val camera1SourceMap: MutableMap<String, Source> = HashMap()
+    private val camera2IdMap: MutableMap<Source, String> = EnumMap(Source::class.java)
+    private val camera2SourceMap: MutableMap<String, Source> = HashMap()
     private var cameraManager: CameraManager? = null
-    private val camera2Listener = object : Camera2Capturer.Listener {
-        override fun onFirstFrameAvailable() {
-            Log.i(TAG, "onFirstFrameAvailable")
-        }
 
-        override fun onCameraSwitched(newCameraId: String) {
-            Log.i(TAG, "onCameraSwitched: newCameraId = $newCameraId")
-        }
-
-        override fun onError(camera2CapturerException: Camera2Capturer.Exception) {
-            Log.e(TAG, camera2CapturerException.toString())
-        }
+    enum class Source {
+        FRONT_CAMERA, BACK_CAMERA
     }
-    val cameraSource: CameraCapturer.CameraSource
+
+    val cameraSource: Source
         get() {
-            if (usingCamera1()) {
-                return camera1Capturer!!.cameraSource
+            val source = if (usingCamera1()) {
+                requireNotNull(camera1Capturer)
+                camera1SourceMap[camera1Capturer.cameraId]
             } else {
-                return getCameraSource(camera2Capturer!!.cameraId)
+                requireNotNull(camera2Capturer)
+                camera2SourceMap[camera2Capturer.cameraId]
             }
-        }
-    /*
-     * This property is required because this class is not an implementation of VideoCapturer due to
-     * a shortcoming in the Video Android SDK.
-     */
-    val videoCapturer: VideoCapturer
-        get() {
-            if (usingCamera1()) {
-                return camera1Capturer!!
-            } else {
-                return camera2Capturer!!
-            }
+            requireNotNull(source)
+            return source
         }
 
+    override fun initialize(
+        surfaceTextureHelper: SurfaceTextureHelper,
+        context: Context,
+        capturerObserver: CapturerObserver
+    ) {
+        activeCapturer.initialize(surfaceTextureHelper, context, capturerObserver)
+    }
 
-    init {
-        if (Camera2Capturer.isSupported(context) && isLollipopApiSupported()) {
-            cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager?;
-            setCameraPairs(context)
-            camera2Capturer = Camera2Capturer(context,
-                    getCameraId(cameraSource),
-                    camera2Listener)
-        } else {
-            camera1Capturer = CameraCapturer(context, cameraSource)
-        }
+    override fun startCapture(width: Int, height: Int, framerate: Int) {
+        activeCapturer.startCapture(width, height, framerate)
+    }
+
+    @Throws(InterruptedException::class)
+    override fun stopCapture() {
+        activeCapturer.stopCapture()
+    }
+
+    override fun isScreencast(): Boolean {
+        return activeCapturer.isScreencast
+    }
+
+    override fun dispose() {
+        activeCapturer.dispose()
     }
 
     fun switchCamera() {
+        val cameraSource = cameraSource
+        val idMap: Map<Source, String> = if (usingCamera1()) camera1IdMap else camera2IdMap
+        val newCameraId =
+            if (cameraSource == Source.FRONT_CAMERA) idMap[Source.BACK_CAMERA] else idMap[Source.FRONT_CAMERA]
         if (usingCamera1()) {
-            camera1Capturer!!.switchCamera()
+            newCameraId?.let { camera1Capturer?.switchCamera(it) }
         } else {
-            val cameraSource = getCameraSource(camera2Capturer!!
-                    .cameraId)
-
-            if (cameraSource == CameraCapturer.CameraSource.FRONT_CAMERA) {
-                camera2Capturer!!.switchCamera(backCameraPair!!.second)
-            } else {
-                camera2Capturer!!.switchCamera(frontCameraPair!!.second)
-            }
+            newCameraId?.let { camera2Capturer?.switchCamera(it) }
         }
     }
 
@@ -90,61 +87,60 @@ class CameraCapturerCompat(context: Context, cameraSource: CameraCapturer.Camera
         return camera1Capturer != null
     }
 
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
-    private fun setCameraPairs(context: Context) {
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    private fun setCamera2Maps(context: Context) {
         val camera2Enumerator = Camera2Enumerator(context)
         for (cameraId in camera2Enumerator.deviceNames) {
             if (isCameraIdSupported(cameraId)) {
                 if (camera2Enumerator.isFrontFacing(cameraId)) {
-                    frontCameraPair = Pair(CameraCapturer.CameraSource.FRONT_CAMERA, cameraId)
+                    camera2IdMap[Source.FRONT_CAMERA] = cameraId
+                    camera2SourceMap[cameraId] = Source.FRONT_CAMERA
                 }
                 if (camera2Enumerator.isBackFacing(cameraId)) {
-                    backCameraPair = Pair(CameraCapturer.CameraSource.BACK_CAMERA, cameraId)
+                    camera2IdMap[Source.BACK_CAMERA] = cameraId
+                    camera2SourceMap[cameraId] = Source.BACK_CAMERA
                 }
             }
         }
     }
 
-    private fun getCameraId(cameraSource: CameraCapturer.CameraSource): String {
-        return if (frontCameraPair!!.first == cameraSource) {
-            frontCameraPair!!.second
-        } else {
-            backCameraPair!!.second
+    private fun setCamera1Maps() {
+        val camera1Enumerator = Camera1Enumerator()
+        for (deviceName in camera1Enumerator.deviceNames) {
+            if (camera1Enumerator.isFrontFacing(deviceName)) {
+                camera1IdMap[Source.FRONT_CAMERA] = deviceName
+                camera1SourceMap[deviceName] = Source.FRONT_CAMERA
+            }
+            if (camera1Enumerator.isBackFacing(deviceName)) {
+                camera1IdMap[Source.BACK_CAMERA] = deviceName
+                camera1SourceMap[deviceName] = Source.BACK_CAMERA
+            }
         }
     }
 
-    private fun getCameraSource(cameraId: String): CameraCapturer.CameraSource {
-        return if (frontCameraPair!!.second == cameraId) {
-            frontCameraPair!!.first
-        } else {
-            backCameraPair!!.first
-        }
-    }
-
-    private fun isLollipopApiSupported(): Boolean {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
-    }
+    private val isLollipopApiSupported: Boolean
+        get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
 
     @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     private fun isCameraIdSupported(cameraId: String): Boolean {
         var isMonoChromeSupported = false
         var isPrivateImageFormatSupported = false
-        val cameraCharacteristics: CameraCharacteristics?
-        try {
-            cameraCharacteristics = cameraManager?.getCameraCharacteristics(cameraId)
+        val cameraCharacteristics: CameraCharacteristics
+        cameraCharacteristics = try {
+            cameraManager!!.getCameraCharacteristics(cameraId)
         } catch (e: Exception) {
             e.printStackTrace()
             return false
         }
-
         /*
          * This is a temporary work around for a RuntimeException that occurs on devices which contain cameras
          * that do not support ImageFormat.PRIVATE output formats. A long term fix is currently in development.
          * https://github.com/twilio/video-quickstart-android/issues/431
          */
-        val streamMap = cameraCharacteristics?.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            isPrivateImageFormatSupported = streamMap?.isOutputSupportedFor(ImageFormat.PRIVATE) ?: false
+        val streamMap =
+            cameraCharacteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)
+        if (streamMap != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            isPrivateImageFormatSupported = streamMap.isOutputSupportedFor(ImageFormat.PRIVATE)
         }
 
         /*
@@ -152,12 +148,30 @@ class CameraCapturerCompat(context: Context, cameraSource: CameraCapturer.Camera
          * SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_MONO or SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_NIR.
          * Visit this link for details on supported values - https://developer.android.com/reference/android/hardware/camera2/CameraCharacteristics#SENSOR_INFO_COLOR_FILTER_ARRANGEMENT
          */
-        val colorFilterArrangement = cameraCharacteristics?.get(CameraCharacteristics.SENSOR_INFO_COLOR_FILTER_ARRANGEMENT) ?: -1
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            isMonoChromeSupported = (colorFilterArrangement == CameraMetadata.SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_MONO
-                    || colorFilterArrangement == CameraMetadata.SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_NIR)
+        val colorFilterArrangement = cameraCharacteristics.get(
+            CameraCharacteristics.SENSOR_INFO_COLOR_FILTER_ARRANGEMENT
+        )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && colorFilterArrangement != null) {
+            isMonoChromeSupported = (colorFilterArrangement
+                    == CameraMetadata.SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_MONO
+                    || colorFilterArrangement
+                    == CameraMetadata.SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_NIR)
         }
         return isPrivateImageFormatSupported && !isMonoChromeSupported
+    }
+
+    init {
+        if (Camera2Capturer.isSupported(context) && isLollipopApiSupported) {
+            cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+            setCamera2Maps(context)
+            camera2Capturer = Camera2Capturer(context, camera2IdMap[cameraSource]!!)
+            activeCapturer = camera2Capturer
+            camera1Capturer = null
+        } else {
+            setCamera1Maps()
+            camera1Capturer = CameraCapturer(context, camera1IdMap[cameraSource]!!)
+            activeCapturer = camera1Capturer
+            camera2Capturer = null
+        }
     }
 }

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/CameraCapturerCompat.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/CameraCapturerCompat.kt
@@ -1,5 +1,6 @@
 package com.twilio.video.quickstart.kotlin
 
+import android.annotation.TargetApi
 import android.content.Context
 import android.graphics.ImageFormat
 import android.hardware.camera2.CameraCharacteristics
@@ -27,7 +28,6 @@ class CameraCapturerCompat(context: Context, cameraSource: Source) : VideoCaptur
     private val camera1SourceMap: MutableMap<String, Source> = HashMap()
     private val camera2IdMap: MutableMap<Source, String> = EnumMap(Source::class.java)
     private val camera2SourceMap: MutableMap<String, Source> = HashMap()
-    private var cameraManager: CameraManager? = null
 
     enum class Source {
         FRONT_CAMERA, BACK_CAMERA
@@ -87,11 +87,11 @@ class CameraCapturerCompat(context: Context, cameraSource: Source) : VideoCaptur
         return camera1Capturer != null
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private fun setCamera2Maps(context: Context) {
         val camera2Enumerator = Camera2Enumerator(context)
         for (cameraId in camera2Enumerator.deviceNames) {
-            if (isCameraIdSupported(cameraId)) {
+            if (isCameraIdSupported(context, cameraId)) {
                 if (camera2Enumerator.isFrontFacing(cameraId)) {
                     camera2IdMap[Source.FRONT_CAMERA] = cameraId
                     camera2SourceMap[cameraId] = Source.FRONT_CAMERA
@@ -121,13 +121,14 @@ class CameraCapturerCompat(context: Context, cameraSource: Source) : VideoCaptur
     private val isLollipopApiSupported: Boolean
         get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
 
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    private fun isCameraIdSupported(cameraId: String): Boolean {
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private fun isCameraIdSupported(context: Context, cameraId: String): Boolean {
         var isMonoChromeSupported = false
         var isPrivateImageFormatSupported = false
+        val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
         val cameraCharacteristics: CameraCharacteristics
         cameraCharacteristics = try {
-            cameraManager!!.getCameraCharacteristics(cameraId)
+            cameraManager.getCameraCharacteristics(cameraId)
         } catch (e: Exception) {
             e.printStackTrace()
             return false
@@ -162,7 +163,6 @@ class CameraCapturerCompat(context: Context, cameraSource: Source) : VideoCaptur
 
     init {
         if (Camera2Capturer.isSupported(context) && isLollipopApiSupported) {
-            cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
             setCamera2Maps(context)
             camera2Capturer = Camera2Capturer(context, camera2IdMap[cameraSource]!!)
             activeCapturer = camera2Capturer

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
@@ -405,7 +405,7 @@ class VideoActivity : AppCompatActivity() {
     private var localVideoTrack: LocalVideoTrack? = null
     private var alertDialog: android.support.v7.app.AlertDialog? = null
     private val cameraCapturerCompat by lazy {
-        CameraCapturerCompat(this, getAvailableCameraSource())
+        CameraCapturerCompat(this, CameraCapturerCompat.Source.FRONT_CAMERA)
     }
     private val sharedPreferences by lazy {
         PreferenceManager.getDefaultSharedPreferences(this@VideoActivity)
@@ -486,7 +486,7 @@ class VideoActivity : AppCompatActivity() {
         localVideoTrack = if (localVideoTrack == null && checkPermissionForCameraAndMicrophone()) {
             LocalVideoTrack.create(this,
                     true,
-                    cameraCapturerCompat.videoCapturer)
+                    cameraCapturerCompat)
         } else {
             localVideoTrack
         }
@@ -608,14 +608,7 @@ class VideoActivity : AppCompatActivity() {
         // Share your camera
         localVideoTrack = LocalVideoTrack.create(this,
                 true,
-                cameraCapturerCompat.videoCapturer)
-    }
-
-    private fun getAvailableCameraSource(): CameraCapturer.CameraSource {
-        return if (CameraCapturer.isSourceAvailable(CameraCapturer.CameraSource.FRONT_CAMERA))
-            CameraCapturer.CameraSource.FRONT_CAMERA
-        else
-            CameraCapturer.CameraSource.BACK_CAMERA
+                cameraCapturerCompat)
     }
 
     private fun setAccessToken() {
@@ -805,7 +798,7 @@ class VideoActivity : AppCompatActivity() {
             }
             localVideoView = thumbnailVideoView
             thumbnailVideoView.mirror = cameraCapturerCompat.cameraSource ==
-                    CameraCapturer.CameraSource.FRONT_CAMERA
+                   CameraCapturerCompat.Source.FRONT_CAMERA
         }
     }
 
@@ -842,7 +835,7 @@ class VideoActivity : AppCompatActivity() {
             }
             localVideoView = primaryVideoView
             primaryVideoView.mirror = cameraCapturerCompat.cameraSource ==
-                    CameraCapturer.CameraSource.FRONT_CAMERA
+                   CameraCapturerCompat.Source.FRONT_CAMERA
         }
     }
 
@@ -881,9 +874,9 @@ class VideoActivity : AppCompatActivity() {
             val cameraSource = cameraCapturerCompat.cameraSource
             cameraCapturerCompat.switchCamera()
             if (thumbnailVideoView.visibility == View.VISIBLE) {
-                thumbnailVideoView.mirror = cameraSource == CameraCapturer.CameraSource.BACK_CAMERA
+                thumbnailVideoView.mirror = cameraSource == CameraCapturerCompat.Source.BACK_CAMERA
             } else {
-                primaryVideoView.mirror = cameraSource == CameraCapturer.CameraSource.BACK_CAMERA
+                primaryVideoView.mirror = cameraSource == CameraCapturerCompat.Source.BACK_CAMERA
             }
         }
     }


### PR DESCRIPTION
* Programmable Video Android SDK 6.0.0-preview3 [[bintray]](https://bintray.com/twilio/releases/video-android/6.0.0-preview3), [[docs]](https://twilio.github.io/twilio-video-android/docs/6.0.0-preview3/)

##### Enhancements

* Added `useDtx` parameter for constraining bitrate while using Opus codec. `useDtx` is enabled by default.
Disabling `useDtx` will result in higher bitrate for silent audio while using Opus codec.

##### API Updates

* `OpusCodec` class has a new constructor that takes `useDtx` as an input `OpusCodec(boolean useDtx)`. Use this to explicitly enable or disable DTX.
* Removed `IceOptions.abortOnIceServersTimeout` and `IceOptions.iceServersTimeout`.
* Removed `CameraCapturer.CameraSource`. `CameraCapturer` instances are now created using a camera ID as a `String`. You can use `tvi.webrtc.Camera1Enumerator#getDeviceNames()` to query the list of supported camera IDs.
* Updated `CameraCapturer#switchCamera()` signature to require a camera ID. Users now must specify which camera ID to switch to. This behavior is similar to the `Camera2Capturer` switch camera behavior.

    The snippet below demonstrates the updated use of `CameraCapturer`.

    ```kotlin
    // Determine the front and back camera
    val camera1Enumerator = Camera1Enumerator()
    val frontCameraId = camera1Enumerator.deviceNames.find { camera1Enumerator.isFrontFacing(it) }
    val backCameraId = camera1Enumerator.deviceNames.find { camera1Enumerator.isBackFacing(it) }

    // Create the instance
    val cameraCapturer = CameraCapturer(context, frontCameraId)

    // Switch camera Ids
    cameraCapturer.switchCamera(backCameraId)
    ```

* `Camera2Capturer.Listener` implementations are now optional when creating a `Camera2Capturer`
