### PR TITLE
Check audio record is initialized before calling startRecording API

### DIFF
--- a/exampleCustomAudioDevice/src/main/java/com/twilio/video/examples/examplecustomaudiodevice/FileAndMicAudioDevice.kt
+++ b/exampleCustomAudioDevice/src/main/java/com/twilio/video/examples/examplecustomaudiodevice/FileAndMicAudioDevice.kt
@@ -79,19 +79,21 @@ class FileAndMicAudioDevice(private val context: Context) : AudioDevice {
      */
     private val microphoneCapturerRunnable = Runnable {
         Process.setThreadPriority(Process.THREAD_PRIORITY_URGENT_AUDIO)
-        audioRecord?.startRecording()
-        while (true) {
-            val bytesRead = audioRecord?.read(micWriteBuffer!!, micWriteBuffer!!.capacity())
-            if (bytesRead == micWriteBuffer?.capacity()) {
-                AudioDevice.audioDeviceWriteCaptureData(capturingAudioDeviceContext!!, micWriteBuffer!!)
-            } else {
-                val errorMessage = "AudioRecord.read failed: $bytesRead"
-                Log.e(TAG, errorMessage)
-                if (bytesRead == AudioRecord.ERROR_INVALID_OPERATION) {
-                    stopRecording()
+        if (audioRecord.state != AudioRecord.STATE_UNINITIALIZED) {
+            audioRecord?.startRecording()
+            while (true) {
+                val bytesRead = audioRecord?.read(micWriteBuffer!!, micWriteBuffer!!.capacity())
+                if (bytesRead == micWriteBuffer?.capacity()) {
+                    AudioDevice.audioDeviceWriteCaptureData(capturingAudioDeviceContext!!, micWriteBuffer!!)
+                } else {
+                    val errorMessage = "AudioRecord.read failed: $bytesRead"
                     Log.e(TAG, errorMessage)
+                    if (bytesRead == AudioRecord.ERROR_INVALID_OPERATION) {
+                        stopRecording()
+                        Log.e(TAG, errorMessage)
+                    }
+                    break
                 }
-                break
             }
         }
     }


### PR DESCRIPTION
Check audio record is initialized before calling startRecording API.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
