### PR TITLE
VAKTX-17: Use ktx library from Video Android 6.1.0 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
             'retrofit'           : '2.0.0-beta4',
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
-            'videoAndroid'       : '6.0.0',
+            'videoAndroid'       : '6.1.0',
             'audioSwitch'        : '1.1.0'
     ]
 

--- a/quickstartKotlin/build.gradle
+++ b/quickstartKotlin/build.gradle
@@ -63,7 +63,7 @@ dependencies {
 
     implementation project(':common')
     implementation "com.twilio:audioswitch:${versions.audioSwitch}"
-    implementation "com.twilio:video-android:${versions.videoAndroid}"
+    implementation "com.twilio:video-android-ktx:${versions.videoAndroid}"
     implementation "com.android.support.constraint:constraint-layout:${versions.constraintLayout}"
     implementation "com.koushikdutta.ion:ion:${versions.ion}"
     implementation "com.android.support:appcompat-v7:${versions.supportLibrary}"

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
@@ -637,7 +637,8 @@ class VideoActivity : AppCompatActivity() {
 
     private fun connectToRoom(roomName: String) {
         audioSwitch.activate();
-        val connectionOptions = createConnectOptions(accessToken) {
+
+        room = connect(this, accessToken, roomListener) {
             roomName(roomName)
             /*
              * Add local audio track to connect options to share with participants.
@@ -667,10 +668,6 @@ class VideoActivity : AppCompatActivity() {
              * Rooms. Toggling the flag in a P2P room does not modify subscription behavior.
              */
             enableAutomaticSubscription(enableAutomaticSubscription)
-        }
-
-        room = connect(this, accessToken, roomListener) {
-            connectionOptions
         }
         setDisconnectAction()
     }


### PR DESCRIPTION
Used ktx library from Video Android 6.1.0 release.

### 6.1.0

#### New Kotlin Extensions Library

As part of this release, we have created a new Kotlin Extensions Library! This library provides a set of convenience functions and [extensions](https://kotlinlang.org/docs/reference/extensions.html) that provide Kotlin developers with a more idiomatic programming experience.

##### Extension APIs
Below is a list of all of the extension APIs that are now available:
* `AudioOptions.kt`
* `BandwidthProfileOptions.kt`
* `ConnectOptions.kt`
* `DataTrackOptions.kt`
* `IceOptions.kt`
* `LocalAudioTrack.kt`
* `LocalDataTrack.kt`
* `LocalVideoTrack.kt`
* `Video.kt`
* `VideoBandwidthProfileOptions.kt`

#### Getting Started
To get started using this library, replace `implementation com.twilio:video-android:6.0.0` with `implementation com.twilio:video-android-ktx:6.1.0` in your application's `build.gradle` file.

```groovy
implementation 'com.twilio:video-android-ktx:6.1.0'
```

All of the options extensions follow the same pattern. For example, here's how to connect to a room with connect options using Java:

```java
ConnectOptions connectOptions = new ConnectOptions.Builder(accessToken)
    .roomName("my-room")
    .enableAutomaticSubscription(false)
    .build();
room = Video.connect(context, connectOptions, roomListener);
```

The following Kotlin snippet shows how you can call connect with connect options all in one statement using the `Video.kt` connect extension function:
```kotlin
val room = Video.connect(context, token, roomListener) {
    roomName("my-room")
    enableAutomaticSubscription(false)
}
```

The library also introduces extension properties that make it easier to get and set specific Java fields. For example, here's how to check if a `LocalVideoTrack` track is enabled and how to disable it in Java:

```java
LocalVideoTrack localVideoTrack = LocalVideoTrack.create(context, enable, cameraCapturer);

// Check if the track is enabled
localVideoTrack.isEnabled();

// Disable the track
localVideoTrack.enabled(false);
```

The following Kotlin snippet show how to do the same with the enabled extension property that is part of `LocalVideoTrack.kt`:
```kotlin
val localVideoTrack = LocalVideoTrack.create(context, enable, cameraCapturer)

// Check if the track is enabled
localVideoTrack.enabled

// Disable the track
localVideoTrack.enabled = false
```

#### Enhancements

* The following classes now override the `equals` and `hashCode` Object methods
    * `ConnectOptions.java`
    * `IceOptions.java`
    * `BandwidthProfileOptions.java`
    * `VideoBandwidthProfileOptions.java`
    * `AudioOptions.java`
    * `DataTrackOptions.java`
* Added a new `Video.java` static method named `getModuleLogLevel(LogModule module)` that retrieves the log level for the specified `LogModule`.

#### Bug Fixes

 * Fixed a bug where publishing multiple tracks with the same name may result in a crash if network quality is enabled.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
