### PR TITLE
Update video android to 5.14.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
             'retrofit'           : '2.0.0-beta4',
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
-            'videoAndroid'       : '5.13.0',
+            'videoAndroid'       : '5.14.0',
             'audioSwitch'        : '1.1.0'
     ]
 


### PR DESCRIPTION
### 5.14.0

* Programmable Video Android SDK 5.14.0 [[bintray]](https://bintray.com/twilio/releases/video-android/5.14.0), [[docs]](https://twilio.github.io/twilio-video-android/docs/5.14.0/)

Enhancements

- `isRecording()` API now accurately reflects the current recording state of the `Room`. In the previous versions of the SDK, `isRecording()` could return false positives. The `onRecordingStarted(...)` and `onRecordingStopped(...)` callbacks will now be invoked when recording for at least a single track in the `Room` has started and stopped respectively.

Maintenance

* Removed `tvi.webrtc.NetworkMonitor` and `tvi.webrtc.NetworkMonitorAutoDetect` from the `libwebrtc.jar` provided by the SDK.

Known issues

- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. As a result, tracks published after a `Room.State.RECONNECTED` event might not be subscribed to by a `RemoteParticipant`.
