### PR TITLE
Update video android to 6.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
             'retrofit'           : '2.0.0-beta4',
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
-            'videoAndroid'       : '6.2.0',
+            'videoAndroid'       : '6.2.1',
             'audioSwitch'        : '1.1.0'
     ]
 


### PR DESCRIPTION
### 6.2.1

* Programmable Video Android SDK 6.2.1 [[bintray]](https://bintray.com/twilio/releases/video-android/6.2.1), [[docs]](https://twilio.github.io/twilio-video-android/docs/6.2.1/)

#### Bug Fixes

* Fixed a crash that occurred while using either the `CameraCapturer` or `Camera2Capturer`, switching from the front camera to the back camera, and toggling the camera flash.

#### Known issues

* Publishing multiple tracks with the same name results in a crash if network quality is enabled. To avoid this, use unique names for each track in the `Room`.

Size Report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| x86             | 5.5MB           |
| x86_64          | 5.5MB           |
| armeabi-v7a     | 4.1MB           |
| arm64-v8a       | 5.2MB           |
| universal       | 19.6MB          |
