### PR TITLE
VIDEO-4537: Move mavenCentral() above jcenter()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,8 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
         mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath "com.android.tools.build:gradle:${versions.androidGradlePlugin}"
@@ -50,7 +50,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
+        jcenter()
     }
 }


### PR DESCRIPTION
<!-- Describe your Pull Request -->

Move mavenCentral() above jcenter() in the project level build.gradle repositories block.

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
