### PR TITLE
Video Android 6.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
             'retrofit'           : '2.0.0-beta4',
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
-            'videoAndroid'       : '6.3.0',
+            'videoAndroid'       : '6.3.1',
             'audioSwitch'        : '1.1.2'
     ]
 


### PR DESCRIPTION
## 6.3.1

#### Bug Fixes
* Fixed a crash (see stacktrace below) that sometimes occurs on Pixel devices when decoding VP8 video streams.
```
java.lang.IllegalArgumentException: Texture width must be positive, but was 0
     FATAL EXCEPTION: AndroidVideoDecoder.outputThread
Process: com.twilio.video.test, PID: 13001
java.lang.IllegalArgumentException: Texture width must be positive, but was 0
    at tvi.webrtc.SurfaceTextureHelper.setTextureSize(SurfaceTextureHelper.java:256)
    at tvi.webrtc.AndroidVideoDecoder.deliverTextureFrame(AndroidVideoDecoder.java:432)
    at tvi.webrtc.AndroidVideoDecoder.deliverDecodedFrame(AndroidVideoDecoder.java:407)
    at tvi.webrtc.AndroidVideoDecoder$1.run(AndroidVideoDecoder.java:369)
```
* Fixed a bug that could cause a crash when changing log level to Trace at runtime.


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
