### PR TITLE
Use Video Android 6.4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
             'retrofit'           : '2.0.0-beta4',
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
-            'videoAndroid'       : '6.4.0',
+            'videoAndroid'       : '6.4.1',
             'audioSwitch'        : '1.1.2'
     ]
 


### PR DESCRIPTION
Update Android Video to version 6.4.1

#### Bug Fixes

* Fixed a crash when `maxTracks` or `renderDimensions` is set and a sink is added for a `RemoteVideoTrack`.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
