### PR TITLE
Use Video Android 7.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The following snippet shows an example `build.gradle` with APK splits enabled.
     }
 
     dependencies {
-        compile "com.twilio:video-android:7.0.1"
+        compile "com.twilio:video-android:7.0.2"
     }
 
 The adoption of APK splits requires developers to submit multiple APKs to the Play Store. Refer to [Google’s documentation](https://developer.android.com/google/play/publishing/multiple-apks.html) for how to support this in your application.

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
             'retrofit'           : '2.0.0-beta4',
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
-            'videoAndroid'       : '7.0.1',
+            'videoAndroid'       : '7.0.2',
             'audioSwitch'        : '1.1.2'
     ]
 


### PR DESCRIPTION
#### New Features

- The SDK now supports audio only rooms and added two error codes, ROOM_AUDIO_ONLY_FLAG_NOT_SUPPORTED_EXCEPTION (53124) & TRACK_TRACK_KIND_NOT_SUPPORTED_EXCEPTION (53125).

#### Enhancements

- Improved reconnection time after network connectivity disruptions.

#### Known Issues

- As of 6.0.0 of the SDK, hardware video encoding doesn't publish all of the three simulcast layers when VP8 simulcast is enabled on Android.
  This affects Video Content Preferences from working properly for subscribing video participants since the feature requires all three simulcast layers to switch between.
  Our team is working on a fix for this, but the feature does work when VP8 simulcast is used to publish video from participants using the Javascript or iOS SDKs.
- Video Content Preferences might prefer larger video than needed when device orientations are mismatched. For example, if a participant in landscape mode publishes video, then the subscribing participant must also be in landscape mode in order for the correctly sized simulcast layers to be selected. The same is true for the portrait orientation.
- When the publisher is publishing video at 720p with VP8 simulcast enabled and the subscriber varies their hints between 180p, 360p, and 720p, sometimes the subscriber receives larger video than expected.


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
