### PR TITLE
Replace obsolete circleci docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ aliases:
   - &build-defaults
     working_directory: *workspace
     docker:
-      - image: circleci/android:api-30-node
+      - image: cimg/android:2021.10.2-node
     environment:
       - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -Xmx3g"
 


### PR DESCRIPTION
Circle CI has deprecated the `circleci/android` docker images, this PR updates our CI integration to use a suitable new `cimg/android` image instead.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
