### PR TITLE
Updated so that there are not as many compile warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.4.10'
+    ext.kotlin_version = '1.5.0'
     ext.versions = [
             'java'               : JavaVersion.VERSION_1_8,
             'androidGradlePlugin': '4.0.1',

--- a/exampleCustomAudioDevice/src/main/java/com/twilio/video/examples/examplecustomaudiodevice/CustomAudioDeviceActivity.kt
+++ b/exampleCustomAudioDevice/src/main/java/com/twilio/video/examples/examplecustomaudiodevice/CustomAudioDeviceActivity.kt
@@ -251,7 +251,7 @@ class CustomAudioDeviceActivity : AppCompatActivity() {
             val focusRequest = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
                     .setAudioAttributes(playbackAttributes)
                     .setAcceptsDelayedFocusGain(true)
-                    .setOnAudioFocusChangeListener { i: Int -> }
+                    .setOnAudioFocusChangeListener { _: Int -> }
                     .build()
             audioManager?.requestAudioFocus(focusRequest)
         } else {
@@ -374,7 +374,7 @@ class CustomAudioDeviceActivity : AppCompatActivity() {
     }
 
     private fun connectClickListener(roomEditText: EditText): DialogInterface.OnClickListener {
-        return DialogInterface.OnClickListener { dialog: DialogInterface?, which: Int ->
+        return DialogInterface.OnClickListener { _: DialogInterface?, _: Int ->
             /*
              * Connect to room
              */
@@ -383,7 +383,7 @@ class CustomAudioDeviceActivity : AppCompatActivity() {
     }
 
     private fun disconnectClickListener(): View.OnClickListener {
-        return View.OnClickListener { v: View? ->
+        return View.OnClickListener { _: View? ->
             /*
              * Disconnect from room
              */
@@ -393,11 +393,11 @@ class CustomAudioDeviceActivity : AppCompatActivity() {
     }
 
     private fun connectActionClickListener(): View.OnClickListener {
-        return View.OnClickListener { v: View? -> showConnectDialog() }
+        return View.OnClickListener { _: View? -> showConnectDialog() }
     }
 
     private fun cancelConnectDialogClickListener(): DialogInterface.OnClickListener {
-        return DialogInterface.OnClickListener { dialog: DialogInterface?, which: Int ->
+        return DialogInterface.OnClickListener { _: DialogInterface?, _: Int ->
             initializeUI()
             connectDialog?.dismiss()
         }
@@ -410,7 +410,7 @@ class CustomAudioDeviceActivity : AppCompatActivity() {
     }
 
     private fun inputSwitchActionFabClickListener(): View.OnClickListener {
-        return View.OnClickListener { v: View? ->
+        return View.OnClickListener { _: View? ->
             val enable = fileAndMicAudioDevice!!.isMusicPlaying
             applyFabState(inputSwitchFab, !enable)
             fileAndMicAudioDevice!!.switchInput(!enable)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
+org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 android.useAndroidX=false
 android.enableJetifier=false

--- a/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
+++ b/quickstart/src/main/java/com/twilio/video/quickstart/activity/VideoActivity.java
@@ -210,6 +210,7 @@ public class VideoActivity extends AppCompatActivity {
         return true;
     }
 
+    @SuppressLint("NonConstantResourceId")
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
@@ -174,7 +174,7 @@ class VideoActivity : AppCompatActivity() {
             title = room.name
 
             // Only one participant is supported
-            room.remoteParticipants?.firstOrNull()?.let { addRemoteParticipant(it) }
+            room.remoteParticipants.firstOrNull()?.let { addRemoteParticipant(it) }
         }
 
         override fun onReconnected(room: Room) {


### PR DESCRIPTION
* Fixed issue where quickstart was using an older kotlin std lib than other products (audioswitch, etc..), now using 1.5.0
* Fixed warnings from unnecessary !! and .? null checks.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
