### PR TITLE
VIDEO-12826 - incorrect status onResume, crash when already granted permissions

### DIFF
--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
@@ -548,6 +548,7 @@ class VideoActivity : AppCompatActivity() {
         if (!checkPermissionForCameraAndMicrophone()) {
             requestPermissionForCameraMicrophoneAndBluetooth()
         } else {
+            createAudioAndVideoTracks()
             audioSwitch.start { audioDevices, audioDevice -> updateAudioDeviceIcon(audioDevice) }
         }
         /*
@@ -622,7 +623,7 @@ class VideoActivity : AppCompatActivity() {
             reconnectingProgressBar.visibility = if (it.state != Room.State.RECONNECTING)
                 View.GONE else
                 View.VISIBLE
-            videoStatusTextView.text = "Connected to ${it.name}"
+            if (it.state != Room.State.DISCONNECTED) videoStatusTextView.text = "Connected to ${it.name}"
         }
     }
 

--- a/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
+++ b/quickstartKotlin/src/main/java/com/twilio/video/quickstart/kotlin/VideoActivity.kt
@@ -548,8 +548,8 @@ class VideoActivity : AppCompatActivity() {
         if (!checkPermissionForCameraAndMicrophone()) {
             requestPermissionForCameraMicrophoneAndBluetooth()
         } else {
-            createAudioAndVideoTracks()
             audioSwitch.start { audioDevices, audioDevice -> updateAudioDeviceIcon(audioDevice) }
+            createAudioAndVideoTracks()
         }
         /*
          * Set the initial state of the UI


### PR DESCRIPTION
Issues:
#680 #712 
Changes:
- Should not update status text onResume if Room.State.DISCONNECTED
- Should create video and audio tracks if permissions have been previously already granted.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
