### PR TITLE
Fix screen share SecurityException for API level 34 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Javadoc](https://img.shields.io/badge/javadoc-OK-blue.svg)](https://twilio.github.io/twilio-video-android/docs/latest/)
 
-> [!WARNING]  
-> We are no longer allowing new customers to onboard to Twilio Video. Effective **December 5th, 2024**, Twilio Video will End of Life (EOL) and will cease to function for all customers. Customers may transition to any video provider they choose, however, we are recommending customers migrate to the Zoom Video SDK and we have prepared a [Migration Guide](https://developers.zoom.us/docs/video-sdk/twilio/). Additional information on this EOL is available in our Help Center [here](https://support.twilio.com/hc/en-us/articles/20950630029595-Programmable-Video-End-of-Life-Notice). 
+> [!WARNING]
+> We are no longer allowing new customers to onboard to Twilio Video. Effective **December 5th, 2024**, Twilio Video will End of Life (EOL) and will cease to function for all customers. Customers may transition to any video provider they choose, however, we are recommending customers migrate to the Zoom Video SDK and we have prepared a [Migration Guide](https://developers.zoom.us/docs/video-sdk/twilio/). Additional information on this EOL is available in our Help Center [here](https://support.twilio.com/hc/en-us/articles/20950630029595-Programmable-Video-End-of-Life-Notice).
 
 **Tip:** Please check out the open-sourced [video collaboration app](https://github.com/twilio/twilio-video-app-android)
 built with the Android Video SDK.

--- a/exampleScreenCapturer/src/main/java/com/twilio/video/examples/screencapturer/ScreenCapturerActivity.java
+++ b/exampleScreenCapturer/src/main/java/com/twilio/video/examples/screencapturer/ScreenCapturerActivity.java
@@ -2,6 +2,7 @@ package com.twilio.video.examples.screencapturer;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.media.projection.MediaProjectionManager;
 import android.os.Build;
 import android.os.Bundle;
@@ -75,7 +76,10 @@ public class ScreenCapturerActivity extends AppCompatActivity {
             case R.id.share_screen_menu_item:
                 String shareScreen = getString(R.string.share_screen);
                 if (item.getTitle().equals(shareScreen)) {
-                    if (null != screenCapturer) {
+                    if (Build.VERSION.SDK_INT >= 34) {
+                        requestScreenCapturePermission();
+                    }
+                    else if (null != screenCapturer) {
                         if (Build.VERSION.SDK_INT >= 29) {
                             screenCapturerManager.startForeground();
                         }
@@ -93,6 +97,15 @@ public class ScreenCapturerActivity extends AppCompatActivity {
                 return true;
             default:
                 return super.onOptionsItemSelected(item);
+        }
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        if (Build.VERSION.SDK_INT >= 34 && screenVideoTrack != null) {
+            screenVideoTrack.release();
+            requestScreenCapturePermission();
         }
     }
 

--- a/exampleScreenCapturer/src/main/java/com/twilio/video/examples/screencapturer/ScreenCapturerActivity.java
+++ b/exampleScreenCapturer/src/main/java/com/twilio/video/examples/screencapturer/ScreenCapturerActivity.java
@@ -121,7 +121,7 @@ public class ScreenCapturerActivity extends AppCompatActivity {
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode == REQUEST_MEDIA_PROJECTION) {
-            if (resultCode != AppCompatActivity.RESULT_OK) {
+            if (resultCode != AppCompatActivity.RESULT_OK || data == null) {
                 Toast.makeText(
                                 this,
                                 R.string.screen_capture_permission_not_granted,

--- a/exampleScreenCapturer/src/main/java/com/twilio/video/examples/screencapturer/ScreenCapturerActivity.java
+++ b/exampleScreenCapturer/src/main/java/com/twilio/video/examples/screencapturer/ScreenCapturerActivity.java
@@ -78,8 +78,7 @@ public class ScreenCapturerActivity extends AppCompatActivity {
                 if (item.getTitle().equals(shareScreen)) {
                     if (Build.VERSION.SDK_INT >= 34) {
                         requestScreenCapturePermission();
-                    }
-                    else if (null != screenCapturer) {
+                    } else if (null != screenCapturer) {
                         if (Build.VERSION.SDK_INT >= 29) {
                             screenCapturerManager.startForeground();
                         }


### PR DESCRIPTION
<!-- Describe your Pull Request -->
Starting from API 34 it is required for user to consent for each MediaProjection capture session.
Adding screen capture permission each time screen share is selected and when orientation is changed on device rotation.
Issue #753 
[Link to Android changes](https://developer.android.com/about/versions/14/behavior-changes-14#media-projection-consent)
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
