### PR TITLE
[VBLOCKS-6224] Fix crash in Release builds

### DIFF
--- a/quickstart/proguard-rules.pro
+++ b/quickstart/proguard-rules.pro
@@ -1,4 +1,5 @@
 -keep class tvi.webrtc.** { *; }
+-keep class org.jni_zero.** { *; }
 -keep class com.twilio.video.** { *; }
 -keep class com.twilio.common.** { *; }
 -keepattributes InnerClasses

--- a/quickstartKotlin/proguard-rules.pro
+++ b/quickstartKotlin/proguard-rules.pro
@@ -20,6 +20,7 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 -keep class tvi.webrtc.** { *; }
+-keep class org.jni_zero.** { *; }
 -keep class com.twilio.video.** { *; }
 -keep class com.twilio.common.** { *; }
 -keepattributes InnerClasses


### PR DESCRIPTION
### Description
Added proguard rule to fix crash caused by "java.lang.ClassNotFoundException: org.jni_zero.JniInit"

Related ticket: https://twilio-engineering.atlassian.net/browse/VBLOCKS-6224

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
